### PR TITLE
Skip a leading UTF-8 BOM before parsing headers

### DIFF
--- a/kotlin-dsv/src/commonMain/kotlin/dev/sargunv/kotlindsv/DsvParser.kt
+++ b/kotlin-dsv/src/commonMain/kotlin/dev/sargunv/kotlindsv/DsvParser.kt
@@ -5,8 +5,9 @@ import kotlinx.io.Source
 /**
  * Low-level parser for [DSV][DsvFormat] data.
  *
- * Reads from a UTF-8 [Source] and parses according to the provided [DsvScheme]. For typical use
- * cases, prefer using [DsvFormat] instead.
+ * Reads from a UTF-8 [Source] and parses according to the provided [DsvScheme]. A leading UTF-8 BOM
+ * (U+FEFF) is skipped before the first field; BOM characters in later fields are preserved. For
+ * typical use cases, prefer using [DsvFormat] instead.
  */
 public class DsvParser(private val input: Source, private val scheme: DsvScheme) {
   private var data = StringBuilder()
@@ -155,7 +156,9 @@ public class DsvParser(private val input: Source, private val scheme: DsvScheme)
    */
   public fun parseRecords(): Sequence<List<String>> = sequence {
     input.use {
-      val (firstRecord, pos) = readRecord(0) ?: return@use
+      // UTF-8 BOM is an encoding prefix, not part of the first field
+      val start = if (charAt(0) == UTF8_BOM) 1 else 0
+      val (firstRecord, pos) = readRecord(start) ?: return@use
       var cursor =
         readEndOfLine(pos)?.newPos
           ?: throw DsvParseException("Expected end of line, got '${charAt(pos)}'")
@@ -207,5 +210,6 @@ public class DsvParser(private val input: Source, private val scheme: DsvScheme)
 
   private companion object {
     private const val MAX_UTF8_INCOMPLETE_BYTES = 3
+    private const val UTF8_BOM = '\uFEFF'
   }
 }

--- a/kotlin-dsv/src/commonMain/kotlin/dev/sargunv/kotlindsv/DsvParser.kt
+++ b/kotlin-dsv/src/commonMain/kotlin/dev/sargunv/kotlindsv/DsvParser.kt
@@ -5,9 +5,8 @@ import kotlinx.io.Source
 /**
  * Low-level parser for [DSV][DsvFormat] data.
  *
- * Reads from a UTF-8 [Source] and parses according to the provided [DsvScheme]. A leading UTF-8 BOM
- * (U+FEFF) is skipped before the first field; BOM characters in later fields are preserved. For
- * typical use cases, prefer using [DsvFormat] instead.
+ * Reads from a UTF-8 [Source] and parses according to the provided [DsvScheme]. For typical use
+ * cases, prefer using [DsvFormat] instead.
  */
 public class DsvParser(private val input: Source, private val scheme: DsvScheme) {
   private var data = StringBuilder()

--- a/kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/EncoderDecoderTest.kt
+++ b/kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/EncoderDecoderTest.kt
@@ -3,6 +3,7 @@ package dev.sargunv.kotlindsv
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 class EncoderDecoderTest {
@@ -215,6 +216,14 @@ class EncoderDecoderTest {
       """
         .trimIndent()
     assertEquals(expectedEncoded, encoded)
+  }
+
+  @Test
+  fun decodeLeadingUtf8Bom() {
+    @Serializable data class Row(@SerialName("agency_id") val agencyId: String)
+
+    val csv = "\uFEFFagency_id\nDTA\n"
+    assertEquals(listOf(Row("DTA")), format.decodeFromString<Row>(csv))
   }
 
   @Test

--- a/kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/ParserTest.kt
+++ b/kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/ParserTest.kt
@@ -156,4 +156,42 @@ class ParserTest {
     testCase("a,b,c\n1,2,3\nextra") {
       assertFailsWith<DsvParseException> { parseRecords().toList() }
     }
+
+  @Test
+  fun leadingUtf8Bom() =
+    testCase("\uFEFFa,b,c") { assertEquals(listOf(listOf("a", "b", "c")), parseRecords().toList()) }
+
+  @Test
+  fun leadingUtf8BomTable() =
+    testCase("\uFEFFagency_id\nDTA") {
+      val (header, rows) = parseTable()
+      assertEquals(listOf("agency_id"), header)
+      assertEquals(listOf(listOf("DTA")), rows.toList())
+    }
+
+  @Test
+  fun leadingUtf8BomQuotedField() =
+    testCase("\uFEFF\"a,b\",c") {
+      assertEquals(listOf(listOf("a,b", "c")), parseRecords().toList())
+    }
+
+  @Test
+  fun bomInsideQuotedFirstFieldIsPreserved() =
+    testCase("\"\uFEFFa\",b") {
+      assertEquals(listOf(listOf("\uFEFFa", "b")), parseRecords().toList())
+    }
+
+  @Test fun bomOnly() = testCase("\uFEFF") { assertEquals(emptyList(), parseRecords().toList()) }
+
+  @Test
+  fun bomInLaterFieldIsPreserved() =
+    testCase("a,\uFEFFb,c") {
+      assertEquals(listOf(listOf("a", "\uFEFFb", "c")), parseRecords().toList())
+    }
+
+  @Test
+  fun bomInLaterRowIsPreserved() =
+    testCase("a,b\n\uFEFF1,2") {
+      assertEquals(listOf(listOf("a", "b"), listOf("\uFEFF1", "2")), parseRecords().toList())
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

`DsvParser` now skips a leading UTF-8 BOM (`U+FEFF`) at the start of the stream, before the first field. Excel-style “UTF-8 with BOM” files and GTFS feeds use this prefix; Kotlin `trim()` does not treat it as whitespace, so the first header became `\uFEFFagency_id` and failed to match `agency_id`.

BOM characters in later fields or later rows are left unchanged.

Fixes #37

## Checklist

- [x] Briefly describe the changes in this PR.
- [x] Link to related issues.
- [x] Write tests for all new functionality.
- [x] Disclose if and to what extent an AI coding assistant was used.
- [x] Run `./gradlew updateLegacyAbi` to dump the public API for review.

An AI coding assistant implemented this change.

No public API surface change; ABI dump is unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f9df2f7-bb39-4ac0-b3ed-e845bac736f6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f9df2f7-bb39-4ac0-b3ed-e845bac736f6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

