### PR TITLE
Add allowJaggedRows for uneven table rows

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -79,6 +79,19 @@ Handle CSVs with incomplete or extra columns:
 --8<-- "kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/DocsTest.kt:missing-columns"
 ```
 
+## Jagged Rows
+
+Handle CSVs where data rows have fewer or more columns than the header. Short rows are padded with
+empty values; long rows are truncated to the header width:
+
+```kotlin
+--8<-- "kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/DocsTest.kt:jagged-rows"
+```
+
+This is a parser-level option on
+[DsvScheme](./api/kotlin-dsv/dev.sargunv.kotlindsv/-dsv-scheme/index.html), separate from
+`treatMissingColumnsAsNull` / `ignoreUnknownKeys`, which apply to the header vs. the class shape.
+
 ## Enum Serialization
 
 Serialize enums by name or ordinal:

--- a/kotlin-dsv/api/kotlin-dsv.api
+++ b/kotlin-dsv/api/kotlin-dsv.api
@@ -130,9 +130,10 @@ public final class dev/sargunv/kotlindsv/DsvScheme {
 	public fun <init> (CC)V
 	public fun <init> (CCZ)V
 	public fun <init> (CCZZ)V
-	public synthetic fun <init> (CCZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun copy (CCZZ)Ldev/sargunv/kotlindsv/DsvScheme;
-	public static synthetic fun copy$default (Ldev/sargunv/kotlindsv/DsvScheme;CCZZILjava/lang/Object;)Ldev/sargunv/kotlindsv/DsvScheme;
+	public fun <init> (CCZZZ)V
+	public synthetic fun <init> (CCZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (CCZZZ)Ldev/sargunv/kotlindsv/DsvScheme;
+	public static synthetic fun copy$default (Ldev/sargunv/kotlindsv/DsvScheme;CCZZZILjava/lang/Object;)Ldev/sargunv/kotlindsv/DsvScheme;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;

--- a/kotlin-dsv/api/kotlin-dsv.klib.api
+++ b/kotlin-dsv/api/kotlin-dsv.klib.api
@@ -96,9 +96,9 @@ final class dev.sargunv.kotlindsv/DsvParser { // dev.sargunv.kotlindsv/DsvParser
 }
 
 final class dev.sargunv.kotlindsv/DsvScheme { // dev.sargunv.kotlindsv/DsvScheme|null[0]
-    constructor <init>(kotlin/Char, kotlin/Char = ..., kotlin/Boolean = ..., kotlin/Boolean = ...) // dev.sargunv.kotlindsv/DsvScheme.<init>|<init>(kotlin.Char;kotlin.Char;kotlin.Boolean;kotlin.Boolean){}[0]
+    constructor <init>(kotlin/Char, kotlin/Char = ..., kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Boolean = ...) // dev.sargunv.kotlindsv/DsvScheme.<init>|<init>(kotlin.Char;kotlin.Char;kotlin.Boolean;kotlin.Boolean;kotlin.Boolean){}[0]
 
-    final fun copy(kotlin/Char = ..., kotlin/Char = ..., kotlin/Boolean = ..., kotlin/Boolean = ...): dev.sargunv.kotlindsv/DsvScheme // dev.sargunv.kotlindsv/DsvScheme.copy|copy(kotlin.Char;kotlin.Char;kotlin.Boolean;kotlin.Boolean){}[0]
+    final fun copy(kotlin/Char = ..., kotlin/Char = ..., kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Boolean = ...): dev.sargunv.kotlindsv/DsvScheme // dev.sargunv.kotlindsv/DsvScheme.copy|copy(kotlin.Char;kotlin.Char;kotlin.Boolean;kotlin.Boolean;kotlin.Boolean){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // dev.sargunv.kotlindsv/DsvScheme.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // dev.sargunv.kotlindsv/DsvScheme.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // dev.sargunv.kotlindsv/DsvScheme.toString|toString(){}[0]

--- a/kotlin-dsv/src/commonMain/kotlin/dev/sargunv/kotlindsv/DsvParser.kt
+++ b/kotlin-dsv/src/commonMain/kotlin/dev/sargunv/kotlindsv/DsvParser.kt
@@ -153,22 +153,14 @@ public class DsvParser(private val input: Source, private val scheme: DsvScheme)
    *
    * Each list represents one record (row). All records must have the same number of fields unless
    * [DsvScheme.allowJaggedRows] is true, in which case later rows are truncated or padded with
-   * empty strings to match the first row.
+   * empty strings to match the first kept row. When [DsvScheme.skipEmptyLines] is true, empty lines
+   * are dropped before that width is chosen.
    */
   public fun parseRecords(): Sequence<List<String>> = sequence {
     input.use {
       // UTF-8 BOM is an encoding prefix, not part of the first field
-      val start = if (charAt(0) == UTF8_BOM) 1 else 0
-      val (firstRecord, pos) = readRecord(start) ?: return@use
-      var cursor =
-        readEndOfLine(pos)?.newPos
-          ?: throw DsvParseException("Expected end of line, got '${charAt(pos)}'")
-
-      data = StringBuilder(data.drop(cursor))
-      cursor = 0
-
-      val numColumns = firstRecord.size
-      yield(firstRecord)
+      var cursor = if (charAt(0) == UTF8_BOM) 1 else 0
+      var numColumns: Int? = null
 
       while (true) {
         val (record, newPos) = readRecord(cursor) ?: break
@@ -179,18 +171,24 @@ public class DsvParser(private val input: Source, private val scheme: DsvScheme)
         data = StringBuilder(data.drop(cursor))
         cursor = 0
 
-        if (scheme.skipEmptyLines && (record.isEmpty() || record.size == 1 && record[0].isEmpty()))
+        if (scheme.skipEmptyLines && isEmptyRecord(record)) continue
+
+        val expectedColumns = numColumns
+        if (expectedColumns == null) {
+          numColumns = record.size
+          yield(record)
           continue
+        }
 
         val normalized =
           when {
-            record.size == numColumns -> record
+            record.size == expectedColumns -> record
             !scheme.allowJaggedRows ->
               throw DsvParseException(
-                "Expected $numColumns columns, got ${record.size} in record $record"
+                "Expected $expectedColumns columns, got ${record.size} in record $record"
               )
-            record.size > numColumns -> record.take(numColumns)
-            else -> record + List(numColumns - record.size) { "" }
+            record.size > expectedColumns -> record.take(expectedColumns)
+            else -> record + List(expectedColumns - record.size) { "" }
           }
 
         yield(normalized)
@@ -201,6 +199,9 @@ public class DsvParser(private val input: Source, private val scheme: DsvScheme)
       }
     }
   }
+
+  private fun isEmptyRecord(record: List<String>): Boolean =
+    record.isEmpty() || record.size == 1 && record[0].isEmpty()
 
   /**
    * Parses the input as a [DsvTable], treating the first record as a header row.

--- a/kotlin-dsv/src/commonMain/kotlin/dev/sargunv/kotlindsv/DsvParser.kt
+++ b/kotlin-dsv/src/commonMain/kotlin/dev/sargunv/kotlindsv/DsvParser.kt
@@ -151,7 +151,9 @@ public class DsvParser(private val input: Source, private val scheme: DsvScheme)
   /**
    * Parses all records from the input as a sequence of string lists.
    *
-   * Each list represents one record (row). All records must have the same number of fields.
+   * Each list represents one record (row). All records must have the same number of fields unless
+   * [DsvScheme.allowJaggedRows] is true, in which case later rows are truncated or padded with
+   * empty strings to match the first row.
    */
   public fun parseRecords(): Sequence<List<String>> = sequence {
     input.use {
@@ -180,13 +182,18 @@ public class DsvParser(private val input: Source, private val scheme: DsvScheme)
         if (scheme.skipEmptyLines && (record.isEmpty() || record.size == 1 && record[0].isEmpty()))
           continue
 
-        if (record.size != numColumns) {
-          throw DsvParseException(
-            "Expected $numColumns columns, got ${record.size} in record $record"
-          )
-        }
+        val normalized =
+          when {
+            record.size == numColumns -> record
+            !scheme.allowJaggedRows ->
+              throw DsvParseException(
+                "Expected $numColumns columns, got ${record.size} in record $record"
+              )
+            record.size > numColumns -> record.take(numColumns)
+            else -> record + List(numColumns - record.size) { "" }
+          }
 
-        yield(record)
+        yield(normalized)
       }
 
       if (cursor < data.length || !input.exhausted()) {

--- a/kotlin-dsv/src/commonMain/kotlin/dev/sargunv/kotlindsv/DsvScheme.kt
+++ b/kotlin-dsv/src/commonMain/kotlin/dev/sargunv/kotlindsv/DsvScheme.kt
@@ -9,6 +9,8 @@ import kotlin.jvm.JvmOverloads
  * @property quote The character used to quote fields containing special characters.
  * @property writeCrlf When true, writes CRLF line endings; otherwise uses LF.
  * @property skipEmptyLines When true, empty lines in the input are skipped during parsing.
+ * @property allowJaggedRows When true, later rows may have fewer or more fields than the first row.
+ *   Short rows are padded with empty strings; long rows are truncated.
  */
 public data class DsvScheme
 @JvmOverloads
@@ -17,6 +19,7 @@ constructor(
   internal val quote: Char = '"',
   internal val writeCrlf: Boolean = true,
   internal val skipEmptyLines: Boolean = false,
+  internal val allowJaggedRows: Boolean = false,
 ) {
   // line delimiters prob shouldn't be configurable
   internal val lineFeed: Char = '\n'

--- a/kotlin-dsv/src/commonMain/kotlin/dev/sargunv/kotlindsv/DsvScheme.kt
+++ b/kotlin-dsv/src/commonMain/kotlin/dev/sargunv/kotlindsv/DsvScheme.kt
@@ -9,8 +9,8 @@ import kotlin.jvm.JvmOverloads
  * @property quote The character used to quote fields containing special characters.
  * @property writeCrlf When true, writes CRLF line endings; otherwise uses LF.
  * @property skipEmptyLines When true, empty lines in the input are skipped during parsing.
- * @property allowJaggedRows When true, later rows may have fewer or more fields than the first row.
- *   Short rows are padded with empty strings; long rows are truncated.
+ * @property allowJaggedRows When true, later rows may have fewer or more fields than the first kept
+ *   row. Short rows are padded with empty strings; long rows are truncated.
  */
 public data class DsvScheme
 @JvmOverloads

--- a/kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/DocsTest.kt
+++ b/kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/DocsTest.kt
@@ -114,6 +114,27 @@ class DocsTest {
     // --8<-- [end:missing-columns]
   }
 
+  @Test
+  fun jaggedRows() {
+    @Serializable data class Person(val name: String, val age: Int, val city: String?)
+
+    // --8<-- [start:jagged-rows]
+    val format = DsvFormat(scheme = Csv.scheme.copy(allowJaggedRows = true))
+
+    val csv =
+      """
+      name,age,city
+      Alice,30,NYC
+      Bob,25
+      Charlie,35,LA,Extra
+      """
+        .trimIndent()
+
+    val people = format.decodeFromString<Person>(csv)
+    // Bob's missing city becomes null; Charlie's extra field is discarded
+    // --8<-- [end:jagged-rows]
+  }
+
   fun streamingFiles() {
     data class MyData(val id: Int, val name: String)
     val myData = emptySequence<MyData>()

--- a/kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/EncoderDecoderTest.kt
+++ b/kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/EncoderDecoderTest.kt
@@ -227,6 +227,29 @@ class EncoderDecoderTest {
   }
 
   @Test
+  fun allowJaggedRows() {
+    val format =
+      DsvFormat(scheme = DsvScheme(delimiter = ',', writeCrlf = false, allowJaggedRows = true))
+
+    @Serializable data class Person(val name: String, val age: Int, val city: String?)
+
+    val csv =
+      """
+      name,age,city
+      Alice,30,NYC
+      Bob,25
+      Charlie,35,LA,Extra
+      """
+        .trimIndent()
+
+    val decoded = format.decodeFromString<Person>(csv)
+    assertEquals(
+      listOf(Person("Alice", 30, "NYC"), Person("Bob", 25, null), Person("Charlie", 35, "LA")),
+      decoded,
+    )
+  }
+
+  @Test
   fun encodeListOfMapsFails() {
     val maps = listOf(mapOf("a" to "1", "b" to "2"), mapOf("a" to "3", "b" to "4"))
     assertFailsWith<IllegalArgumentException> { format.encodeToString(maps) }

--- a/kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/ParserTest.kt
+++ b/kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/ParserTest.kt
@@ -194,4 +194,81 @@ class ParserTest {
     testCase("a,b\n\uFEFF1,2") {
       assertEquals(listOf(listOf("a", "b"), listOf("\uFEFF1", "2")), parseRecords().toList())
     }
+
+  @Test
+  fun jaggedRowsShorter() =
+    testCase("a,b,c\n1,2", scheme = Csv.scheme.copy(allowJaggedRows = true)) {
+      assertEquals(listOf(listOf("a", "b", "c"), listOf("1", "2", "")), parseRecords().toList())
+    }
+
+  @Test
+  fun jaggedRowsLonger() =
+    testCase("a,b,c\n1,2,3,4", scheme = Csv.scheme.copy(allowJaggedRows = true)) {
+      assertEquals(listOf(listOf("a", "b", "c"), listOf("1", "2", "3")), parseRecords().toList())
+    }
+
+  @Test
+  fun jaggedRowsMixed() =
+    testCase("a,b,c\n1\n2,3,4,5\n6,7,8", scheme = Csv.scheme.copy(allowJaggedRows = true)) {
+      assertEquals(
+        listOf(
+          listOf("a", "b", "c"),
+          listOf("1", "", ""),
+          listOf("2", "3", "4"),
+          listOf("6", "7", "8"),
+        ),
+        parseRecords().toList(),
+      )
+    }
+
+  @Test
+  fun jaggedRowsSingleColumn() =
+    testCase("a\n1,2", scheme = Csv.scheme.copy(allowJaggedRows = true)) {
+      assertEquals(listOf(listOf("a"), listOf("1")), parseRecords().toList())
+    }
+
+  @Test
+  fun jaggedRowsWithQuotes() =
+    testCase(
+      "\"a\",\"b\",\"c\"\n\"1\"\n\"2\",\"3\",\"4\",\"5\"",
+      scheme = Csv.scheme.copy(allowJaggedRows = true),
+    ) {
+      assertEquals(
+        listOf(listOf("a", "b", "c"), listOf("1", "", ""), listOf("2", "3", "4")),
+        parseRecords().toList(),
+      )
+    }
+
+  @Test
+  fun jaggedRowsDisabledLonger() =
+    testCase("a,b,c\n1,2,3,4") { assertFailsWith<DsvParseException> { parseRecords().toList() } }
+
+  @Test
+  fun jaggedRowsSkipEmptyLines() =
+    testCase(
+      "a,b,c\n1,2\n\n3,4,5,6",
+      scheme = Csv.scheme.copy(allowJaggedRows = true, skipEmptyLines = true),
+    ) {
+      assertEquals(
+        listOf(listOf("a", "b", "c"), listOf("1", "2", ""), listOf("3", "4", "5")),
+        parseRecords().toList(),
+      )
+    }
+
+  @Test
+  fun jaggedRowsWithBom() =
+    testCase("\uFEFFa,b,c\n1,2", scheme = Csv.scheme.copy(allowJaggedRows = true)) {
+      assertEquals(listOf(listOf("a", "b", "c"), listOf("1", "2", "")), parseRecords().toList())
+    }
+
+  @Test
+  fun jaggedRowsParseTable() =
+    testCase("a,b,c\n1\n2,3,4,5", scheme = Csv.scheme.copy(allowJaggedRows = true)) {
+      val table = parseTable()
+      assertEquals(listOf("a", "b", "c"), table.header)
+      assertEquals(
+        listOf(mapOf("a" to "1", "b" to "", "c" to ""), mapOf("a" to "2", "b" to "3", "c" to "4")),
+        table.recordsAsMaps().toList(),
+      )
+    }
 }

--- a/kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/ParserTest.kt
+++ b/kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/ParserTest.kt
@@ -124,6 +124,18 @@ class ParserTest {
     }
 
   @Test
+  fun leadingEmptyLineSkip() =
+    testCase("\na,b\n1,2", scheme = Csv.scheme.copy(skipEmptyLines = true)) {
+      assertEquals(listOf(listOf("a", "b"), listOf("1", "2")), parseRecords().toList())
+    }
+
+  @Test
+  fun skipEmptyLinesOnlyEmptyInput() =
+    testCase("\n\n", scheme = Csv.scheme.copy(skipEmptyLines = true)) {
+      assertEquals(emptyList(), parseRecords().toList())
+    }
+
+  @Test
   fun trailingNewlineCrlf() =
     testCase("a,b,c\r\n") { assertEquals(listOf(listOf("a", "b", "c")), parseRecords().toList()) }
 
@@ -253,6 +265,21 @@ class ParserTest {
         listOf(listOf("a", "b", "c"), listOf("1", "2", ""), listOf("3", "4", "5")),
         parseRecords().toList(),
       )
+    }
+
+  @Test
+  fun jaggedRowsSkipLeadingEmptyLines() =
+    testCase(
+      "\n\na,b,c\n1,2",
+      scheme = Csv.scheme.copy(allowJaggedRows = true, skipEmptyLines = true),
+    ) {
+      assertEquals(listOf(listOf("a", "b", "c"), listOf("1", "2", "")), parseRecords().toList())
+    }
+
+  @Test
+  fun jaggedRowsLeadingEmptyLineWithoutSkip() =
+    testCase("\na,b\n1,2", scheme = Csv.scheme.copy(allowJaggedRows = true)) {
+      assertEquals(listOf(listOf(""), listOf("a"), listOf("1")), parseRecords().toList())
     }
 
   @Test


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Fresh implementation of jagged-table support (replaces the abandoned approach in #21).

Adds a default-off `allowJaggedRows` flag on `DsvScheme`. When enabled, the first **kept** row is the canonical width:

- later short rows are padded with empty strings
- later long rows are truncated
- `skipEmptyLines` runs in the same pass, so a leading blank line cannot become the width
- default strict column-count validation is unchanged

This is a parser-level option, orthogonal to `treatMissingColumnsAsNull` / `ignoreUnknownKeys` (header vs. class shape). Padded empty fields decode as null for nullable properties.

Binary compatibility of `DsvScheme.copy` / `@JvmOverloads` ctors is out of scope (same as when `skipEmptyLines` was added).

## Checklist

- [x] Briefly describe the changes in this PR.
- [x] Link to related issues. (none filed; follows up on #21)
- [x] Write tests for all new functionality.
- [x] Disclose if and to what extent an AI coding assistant was used. (implemented by Cursor Grok)
- [x] Run `./gradlew updateLegacyAbi` to dump the public API for review.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-50d1c864-fd6a-475b-8c2a-647c68780a48?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-50d1c864-fd6a-475b-8c2a-647c68780a48&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

