### PR TITLE
test(kotlin-dsv): document one-cell custom serializers

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -100,3 +100,19 @@ Serialize enums by name or ordinal:
 --8<-- "kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/DocsTest.kt:enum-class"
 --8<-- "kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/DocsTest.kt:enums"
 ```
+
+## Lists and maps in one cell
+
+When you do not want extra columns, put a list or a map in one CSV cell. `DsvFormat` keeps data
+classes flat. A property whose serializer writes one string uses one column.
+
+```kotlin
+--8<-- "kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/DocsTest.kt:pipe-list-serializer"
+--8<-- "kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/DocsTest.kt:custom-cell-serializer"
+```
+
+An empty cell on a nullable property decodes as null. If you write an empty list as `""` and the
+property is nullable, decode yields null.
+
+Maps work the same way. Write a `KSerializer` that emits one string, for example `key=value` pairs
+joined by `|`.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -101,18 +101,23 @@ Serialize enums by name or ordinal:
 --8<-- "kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/DocsTest.kt:enums"
 ```
 
-## Lists and maps in one cell
+## Put a structured value in one cell
 
-When you do not want extra columns, put a list or a map in one CSV cell. `DsvFormat` keeps data
-classes flat. A property whose serializer writes one string uses one column.
+`DsvFormat` keeps row classes flat. A nested class, list, or map fails when its generated serializer
+opens a structure.
+
+You can still store that value in one column. Give the property a `KSerializer` whose `serialize`
+and `deserialize` write and read one primitive, usually a string. Annotate the property with
+`@Serializable(with = ...)` or register the serializer as `@Contextual`. The format never inspects
+the Kotlin type. It only sees the one primitive encode.
+
+This example joins a list into one cell. A map, a class, or any other type uses the same adapter
+shape.
 
 ```kotlin
 --8<-- "kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/DocsTest.kt:pipe-list-serializer"
 --8<-- "kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/DocsTest.kt:custom-cell-serializer"
 ```
 
-An empty cell on a nullable property decodes as null. If you write an empty list as `""` and the
-property is nullable, decode yields null.
-
-Maps work the same way. Write a `KSerializer` that emits one string, for example `key=value` pairs
-joined by `|`.
+An empty cell on a nullable property decodes as null, even when your serializer would treat `""` as
+an empty list or a default object.

--- a/kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/DocsTest.kt
+++ b/kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/DocsTest.kt
@@ -7,7 +7,13 @@ import kotlinx.io.Buffer
 import kotlinx.io.buffered
 import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 
 class DocsTest {
   @Test
@@ -196,5 +202,39 @@ class DocsTest {
     val csvByOrdinal = formatByOrdinal.encodeToString(items)
     // Output: id,status\n1,0\n2,2
     // --8<-- [end:enums]
+  }
+
+  // --8<-- [start:pipe-list-serializer]
+  object PipeListSerializer : KSerializer<List<String>> {
+    override val descriptor: SerialDescriptor =
+      PrimitiveSerialDescriptor("PipeList", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: List<String>) {
+      encoder.encodeString(value.joinToString("|"))
+    }
+
+    override fun deserialize(decoder: Decoder): List<String> {
+      val raw = decoder.decodeString()
+      return if (raw.isEmpty()) emptyList() else raw.split("|")
+    }
+  }
+
+  // --8<-- [end:pipe-list-serializer]
+
+  @Test
+  fun customCellSerializer() {
+    // --8<-- [start:custom-cell-serializer]
+    @Serializable
+    data class Order(
+      val id: Int,
+      @Serializable(with = PipeListSerializer::class) val items: List<String>,
+    )
+
+    val orders = listOf(Order(1, listOf("item1", "item2")))
+    val csv = Csv.encodeToString(orders)
+    // Output: id,items\n1,item1|item2
+
+    val decoded = Csv.decodeFromString<Order>(csv)
+    // --8<-- [end:custom-cell-serializer]
   }
 }

--- a/kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/EncoderDecoderTest.kt
+++ b/kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/EncoderDecoderTest.kt
@@ -3,8 +3,17 @@ package dev.sargunv.kotlindsv
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.contextual
 
 class EncoderDecoderTest {
 
@@ -25,6 +34,55 @@ class EncoderDecoderTest {
     val status: Status,
     val description: String?,
   )
+
+  object PipeListSerializer : KSerializer<List<String>> {
+    override val descriptor: SerialDescriptor =
+      PrimitiveSerialDescriptor("PipeList", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: List<String>) {
+      encoder.encodeString(value.joinToString("|"))
+    }
+
+    override fun deserialize(decoder: Decoder): List<String> {
+      val raw = decoder.decodeString()
+      return if (raw.isEmpty()) emptyList() else raw.split("|")
+    }
+  }
+
+  object PipeMapSerializer : KSerializer<Map<String, String>> {
+    override val descriptor: SerialDescriptor =
+      PrimitiveSerialDescriptor("PipeMap", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: Map<String, String>) {
+      encoder.encodeString(value.entries.joinToString("|") { "${it.key}=${it.value}" })
+    }
+
+    override fun deserialize(decoder: Decoder): Map<String, String> {
+      val raw = decoder.decodeString()
+      if (raw.isEmpty()) return emptyMap()
+      return raw.split("|").associate {
+        val parts = it.split("=", limit = 2)
+        parts[0] to parts.getOrElse(1) { "" }
+      }
+    }
+  }
+
+  data class Token(val value: String)
+
+  object TokenAsStringSerializer : KSerializer<Token> {
+    override val descriptor: SerialDescriptor =
+      PrimitiveSerialDescriptor("Token", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: Token) {
+      encoder.encodeString(value.value)
+    }
+
+    override fun deserialize(decoder: Decoder): Token = Token(decoder.decodeString())
+  }
+
+  @Serializable data class NestedToken(val kind: String)
+
+  object NestedTokenSerializer : KSerializer<NestedToken> by NestedToken.serializer()
 
   private val format = DsvFormat(DsvScheme(delimiter = ',', writeCrlf = false))
 
@@ -289,5 +347,109 @@ class EncoderDecoderTest {
     assertFailsWith<IllegalArgumentException> {
       format.decodeFromString<Order>("id,items\n1,item1")
     }
+  }
+
+  @Test
+  fun customListSerializerRoundTrip() {
+    @Serializable
+    data class Order(
+      val id: Int,
+      @Serializable(with = PipeListSerializer::class) val items: List<String>,
+    )
+
+    val orders = listOf(Order(1, listOf("item1", "item2")))
+    val result = format.encodeToString(orders)
+
+    val expected =
+      """
+      id,items
+      1,item1|item2
+
+      """
+        .trimIndent()
+
+    assertEquals(expected, result)
+
+    val decoded = format.decodeFromString<Order>(result)
+    assertEquals(orders, decoded)
+  }
+
+  @Test
+  fun customMapSerializerRoundTrip() {
+    @Serializable
+    data class Attrs(
+      val id: Int,
+      @Serializable(with = PipeMapSerializer::class) val attrs: Map<String, String>,
+    )
+
+    val rows = listOf(Attrs(1, mapOf("k" to "v", "k2" to "v2")))
+    val result = format.encodeToString(rows)
+
+    val expected =
+      """
+      id,attrs
+      1,k=v|k2=v2
+
+      """
+        .trimIndent()
+
+    assertEquals(expected, result)
+
+    val decoded = format.decodeFromString<Attrs>(result)
+    assertEquals(rows, decoded)
+  }
+
+  @Test
+  fun contextualPrimitiveLike() {
+    val format =
+      DsvFormat(
+        scheme = DsvScheme(delimiter = ',', writeCrlf = false),
+        serializersModule = SerializersModule { contextual(TokenAsStringSerializer) },
+      )
+
+    @Serializable data class ContextualRow(@Contextual val token: Token)
+
+    val rows = listOf(ContextualRow(Token("abc")))
+    val result = format.encodeToString(rows)
+
+    val expected =
+      """
+      token
+      abc
+
+      """
+        .trimIndent()
+
+    assertEquals(expected, result)
+
+    val decoded = format.decodeFromString<ContextualRow>(result)
+    assertEquals(rows, decoded)
+  }
+
+  @Test
+  fun contextualNestedClassFails() {
+    val format =
+      DsvFormat(
+        scheme = DsvScheme(delimiter = ',', writeCrlf = false),
+        serializersModule = SerializersModule { contextual(NestedTokenSerializer) },
+      )
+
+    @Serializable data class ContextualNestedRow(@Contextual val token: NestedToken)
+
+    assertFailsWith<IllegalArgumentException> {
+      format.encodeToString(listOf(ContextualNestedRow(NestedToken("x"))))
+    }
+  }
+
+  @Test
+  fun emptyCustomListOnNullableIsNull() {
+    @Serializable
+    data class MaybeItems(
+      val id: Int,
+      @Serializable(with = PipeListSerializer::class) val items: List<String>?,
+    )
+
+    val decoded = format.decodeFromString<MaybeItems>("id,items\n1,\n")
+    assertEquals(listOf(MaybeItems(1, null)), decoded)
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds tests and an examples-page how-to that show any property whose serializer writes one primitive already uses one CSV cell.

## Validation

`mise exec -- ./gradlew :kotlin-dsv:jvmTest --tests dev.sargunv.kotlindsv.EncoderDecoderTest --tests dev.sargunv.kotlindsv.DocsTest` passed on JVM (18 and 10 tests, 0 failures). Docs-only follow-up after that run.

## AI assistance

Cursor Grok 4.6 wrote the tests and docs from the prior issue investigation.

Closes #15
Closes #16
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-30d13eb4-f24d-4aa4-a510-d642f7637fe1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-30d13eb4-f24d-4aa4-a510-d642f7637fe1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

