### PR TITLE
Replace writeCrlf with a general RecordDelimiter

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -39,6 +39,14 @@ You can also customize the quote character and line endings:
 --8<-- "kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/DocsTest.kt:custom-quote"
 ```
 
+Use an exact [record delimiter](./api/kotlin-dsv/dev.sargunv.kotlindsv/-record-delimiter/index.html)
+for warehouse dialects such as MySQL `LINES TERMINATED BY`, Snowflake `RECORD_DELIMITER`, or Spark
+`lineSep`:
+
+```kotlin
+--8<-- "kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/DocsTest.kt:custom-record-delimiter"
+```
+
 ## Naming Strategies
 
 Transform property names to match different naming conventions:

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -41,8 +41,7 @@ You can also customize the quote character and line endings:
 
 Use
 [RecordDelimiter.Exact](./api/kotlin-dsv/dev.sargunv.kotlindsv/-record-delimiter/-exact/index.html)
-for warehouse dialects such as MySQL `LINES TERMINATED BY`, Snowflake `RECORD_DELIMITER`, or Spark
-`lineSep`. `Lf` and `CrLf` write one newline and read `\r*\n`:
+to write and read one specific string. `Lf` and `CrLf` write one newline and read `\r*\n`:
 
 ```kotlin
 --8<-- "kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/DocsTest.kt:custom-record-delimiter"

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -39,9 +39,9 @@ You can also customize the quote character and line endings:
 --8<-- "kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/DocsTest.kt:custom-quote"
 ```
 
-Use an exact [record delimiter](./api/kotlin-dsv/dev.sargunv.kotlindsv/-record-delimiter/index.html)
+Use a [record delimiter](./api/kotlin-dsv/dev.sargunv.kotlindsv/-record-delimiter/index.html) string
 for warehouse dialects such as MySQL `LINES TERMINATED BY`, Snowflake `RECORD_DELIMITER`, or Spark
-`lineSep`:
+`lineSep`. `Lf` and `CrLf` write one newline and read LF, CRLF, and CRCRLF:
 
 ```kotlin
 --8<-- "kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/DocsTest.kt:custom-record-delimiter"

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -41,7 +41,7 @@ You can also customize the quote character and line endings:
 
 Use a [record delimiter](./api/kotlin-dsv/dev.sargunv.kotlindsv/-record-delimiter/index.html) string
 for warehouse dialects such as MySQL `LINES TERMINATED BY`, Snowflake `RECORD_DELIMITER`, or Spark
-`lineSep`. `Lf` and `CrLf` write one newline and read LF, CRLF, and CRCRLF:
+`lineSep`. `Lf` and `CrLf` write one newline and read `\r*\n`:
 
 ```kotlin
 --8<-- "kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/DocsTest.kt:custom-record-delimiter"

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -39,7 +39,8 @@ You can also customize the quote character and line endings:
 --8<-- "kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/DocsTest.kt:custom-quote"
 ```
 
-Use a [record delimiter](./api/kotlin-dsv/dev.sargunv.kotlindsv/-record-delimiter/index.html) string
+Use
+[RecordDelimiter.Exact](./api/kotlin-dsv/dev.sargunv.kotlindsv/-record-delimiter/-exact/index.html)
 for warehouse dialects such as MySQL `LINES TERMINATED BY`, Snowflake `RECORD_DELIMITER`, or Spark
 `lineSep`. `Lf` and `CrLf` write one newline and read `\r*\n`:
 

--- a/kotlin-dsv/api/kotlin-dsv.api
+++ b/kotlin-dsv/api/kotlin-dsv.api
@@ -176,35 +176,21 @@ public final class dev/sargunv/kotlindsv/Psv : dev/sargunv/kotlindsv/DsvFormat {
 	public static final field INSTANCE Ldev/sargunv/kotlindsv/Psv;
 }
 
-public abstract class dev/sargunv/kotlindsv/RecordDelimiter {
-	public abstract fun getValue ()Ljava/lang/String;
-}
-
-public final class dev/sargunv/kotlindsv/RecordDelimiter$CrLf : dev/sargunv/kotlindsv/RecordDelimiter {
-	public static final field INSTANCE Ldev/sargunv/kotlindsv/RecordDelimiter$CrLf;
-	public fun equals (Ljava/lang/Object;)Z
-	public fun getValue ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class dev/sargunv/kotlindsv/RecordDelimiter$Exact : dev/sargunv/kotlindsv/RecordDelimiter {
+public final class dev/sargunv/kotlindsv/RecordDelimiter {
+	public static final field Companion Ldev/sargunv/kotlindsv/RecordDelimiter$Companion;
 	public fun <init> (Ljava/lang/String;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Ldev/sargunv/kotlindsv/RecordDelimiter$Exact;
-	public static synthetic fun copy$default (Ldev/sargunv/kotlindsv/RecordDelimiter$Exact;Ljava/lang/String;ILjava/lang/Object;)Ldev/sargunv/kotlindsv/RecordDelimiter$Exact;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
-	public fun getValue ()Ljava/lang/String;
+	public final fun getRead ()Ljava/util/List;
+	public final fun getWrite ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/sargunv/kotlindsv/RecordDelimiter$Lf : dev/sargunv/kotlindsv/RecordDelimiter {
-	public static final field INSTANCE Ldev/sargunv/kotlindsv/RecordDelimiter$Lf;
-	public fun equals (Ljava/lang/Object;)Z
-	public fun getValue ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
+public final class dev/sargunv/kotlindsv/RecordDelimiter$Companion {
+	public final fun getCrLf ()Ldev/sargunv/kotlindsv/RecordDelimiter;
+	public final fun getLf ()Ldev/sargunv/kotlindsv/RecordDelimiter;
 }
 
 public final class dev/sargunv/kotlindsv/ShortRowPolicy : java/lang/Enum {

--- a/kotlin-dsv/api/kotlin-dsv.api
+++ b/kotlin-dsv/api/kotlin-dsv.api
@@ -128,13 +128,13 @@ public final class dev/sargunv/kotlindsv/DsvParser {
 public final class dev/sargunv/kotlindsv/DsvScheme {
 	public fun <init> (C)V
 	public fun <init> (CC)V
-	public fun <init> (CCZ)V
-	public fun <init> (CCZZ)V
-	public fun <init> (CCZZLdev/sargunv/kotlindsv/ShortRowPolicy;)V
-	public fun <init> (CCZZLdev/sargunv/kotlindsv/ShortRowPolicy;Ldev/sargunv/kotlindsv/LongRowPolicy;)V
-	public synthetic fun <init> (CCZZLdev/sargunv/kotlindsv/ShortRowPolicy;Ldev/sargunv/kotlindsv/LongRowPolicy;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun copy (CCZZLdev/sargunv/kotlindsv/ShortRowPolicy;Ldev/sargunv/kotlindsv/LongRowPolicy;)Ldev/sargunv/kotlindsv/DsvScheme;
-	public static synthetic fun copy$default (Ldev/sargunv/kotlindsv/DsvScheme;CCZZLdev/sargunv/kotlindsv/ShortRowPolicy;Ldev/sargunv/kotlindsv/LongRowPolicy;ILjava/lang/Object;)Ldev/sargunv/kotlindsv/DsvScheme;
+	public fun <init> (CCLdev/sargunv/kotlindsv/RecordDelimiter;)V
+	public fun <init> (CCLdev/sargunv/kotlindsv/RecordDelimiter;Z)V
+	public fun <init> (CCLdev/sargunv/kotlindsv/RecordDelimiter;ZLdev/sargunv/kotlindsv/ShortRowPolicy;)V
+	public fun <init> (CCLdev/sargunv/kotlindsv/RecordDelimiter;ZLdev/sargunv/kotlindsv/ShortRowPolicy;Ldev/sargunv/kotlindsv/LongRowPolicy;)V
+	public synthetic fun <init> (CCLdev/sargunv/kotlindsv/RecordDelimiter;ZLdev/sargunv/kotlindsv/ShortRowPolicy;Ldev/sargunv/kotlindsv/LongRowPolicy;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (CCLdev/sargunv/kotlindsv/RecordDelimiter;ZLdev/sargunv/kotlindsv/ShortRowPolicy;Ldev/sargunv/kotlindsv/LongRowPolicy;)Ldev/sargunv/kotlindsv/DsvScheme;
+	public static synthetic fun copy$default (Ldev/sargunv/kotlindsv/DsvScheme;CCLdev/sargunv/kotlindsv/RecordDelimiter;ZLdev/sargunv/kotlindsv/ShortRowPolicy;Ldev/sargunv/kotlindsv/LongRowPolicy;ILjava/lang/Object;)Ldev/sargunv/kotlindsv/DsvScheme;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -174,6 +174,37 @@ public final class dev/sargunv/kotlindsv/LongRowPolicy : java/lang/Enum {
 
 public final class dev/sargunv/kotlindsv/Psv : dev/sargunv/kotlindsv/DsvFormat {
 	public static final field INSTANCE Ldev/sargunv/kotlindsv/Psv;
+}
+
+public abstract class dev/sargunv/kotlindsv/RecordDelimiter {
+	public abstract fun getValue ()Ljava/lang/String;
+}
+
+public final class dev/sargunv/kotlindsv/RecordDelimiter$CrLf : dev/sargunv/kotlindsv/RecordDelimiter {
+	public static final field INSTANCE Ldev/sargunv/kotlindsv/RecordDelimiter$CrLf;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/sargunv/kotlindsv/RecordDelimiter$Exact : dev/sargunv/kotlindsv/RecordDelimiter {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Ldev/sargunv/kotlindsv/RecordDelimiter$Exact;
+	public static synthetic fun copy$default (Ldev/sargunv/kotlindsv/RecordDelimiter$Exact;Ljava/lang/String;ILjava/lang/Object;)Ldev/sargunv/kotlindsv/RecordDelimiter$Exact;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/sargunv/kotlindsv/RecordDelimiter$Lf : dev/sargunv/kotlindsv/RecordDelimiter {
+	public static final field INSTANCE Ldev/sargunv/kotlindsv/RecordDelimiter$Lf;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class dev/sargunv/kotlindsv/ShortRowPolicy : java/lang/Enum {

--- a/kotlin-dsv/api/kotlin-dsv.api
+++ b/kotlin-dsv/api/kotlin-dsv.api
@@ -176,21 +176,35 @@ public final class dev/sargunv/kotlindsv/Psv : dev/sargunv/kotlindsv/DsvFormat {
 	public static final field INSTANCE Ldev/sargunv/kotlindsv/Psv;
 }
 
-public final class dev/sargunv/kotlindsv/RecordDelimiter {
-	public static final field Companion Ldev/sargunv/kotlindsv/RecordDelimiter$Companion;
-	public fun <init> (Ljava/lang/String;)V
-	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public abstract interface class dev/sargunv/kotlindsv/RecordDelimiter {
+	public abstract fun getValue ()Ljava/lang/String;
+}
+
+public final class dev/sargunv/kotlindsv/RecordDelimiter$CrLf : dev/sargunv/kotlindsv/RecordDelimiter {
+	public static final field INSTANCE Ldev/sargunv/kotlindsv/RecordDelimiter$CrLf;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getRead ()Ljava/util/List;
-	public final fun getWrite ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/sargunv/kotlindsv/RecordDelimiter$Companion {
-	public final fun getCrLf ()Ldev/sargunv/kotlindsv/RecordDelimiter;
-	public final fun getLf ()Ldev/sargunv/kotlindsv/RecordDelimiter;
+public final class dev/sargunv/kotlindsv/RecordDelimiter$Exact : dev/sargunv/kotlindsv/RecordDelimiter {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Ldev/sargunv/kotlindsv/RecordDelimiter$Exact;
+	public static synthetic fun copy$default (Ldev/sargunv/kotlindsv/RecordDelimiter$Exact;Ljava/lang/String;ILjava/lang/Object;)Ldev/sargunv/kotlindsv/RecordDelimiter$Exact;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/sargunv/kotlindsv/RecordDelimiter$Lf : dev/sargunv/kotlindsv/RecordDelimiter {
+	public static final field INSTANCE Ldev/sargunv/kotlindsv/RecordDelimiter$Lf;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class dev/sargunv/kotlindsv/ShortRowPolicy : java/lang/Enum {

--- a/kotlin-dsv/api/kotlin-dsv.klib.api
+++ b/kotlin-dsv/api/kotlin-dsv.klib.api
@@ -120,9 +120,9 @@ final class dev.sargunv.kotlindsv/DsvParser { // dev.sargunv.kotlindsv/DsvParser
 }
 
 final class dev.sargunv.kotlindsv/DsvScheme { // dev.sargunv.kotlindsv/DsvScheme|null[0]
-    constructor <init>(kotlin/Char, kotlin/Char = ..., kotlin/Boolean = ..., kotlin/Boolean = ..., dev.sargunv.kotlindsv/ShortRowPolicy = ..., dev.sargunv.kotlindsv/LongRowPolicy = ...) // dev.sargunv.kotlindsv/DsvScheme.<init>|<init>(kotlin.Char;kotlin.Char;kotlin.Boolean;kotlin.Boolean;dev.sargunv.kotlindsv.ShortRowPolicy;dev.sargunv.kotlindsv.LongRowPolicy){}[0]
+    constructor <init>(kotlin/Char, kotlin/Char = ..., dev.sargunv.kotlindsv/RecordDelimiter = ..., kotlin/Boolean = ..., dev.sargunv.kotlindsv/ShortRowPolicy = ..., dev.sargunv.kotlindsv/LongRowPolicy = ...) // dev.sargunv.kotlindsv/DsvScheme.<init>|<init>(kotlin.Char;kotlin.Char;dev.sargunv.kotlindsv.RecordDelimiter;kotlin.Boolean;dev.sargunv.kotlindsv.ShortRowPolicy;dev.sargunv.kotlindsv.LongRowPolicy){}[0]
 
-    final fun copy(kotlin/Char = ..., kotlin/Char = ..., kotlin/Boolean = ..., kotlin/Boolean = ..., dev.sargunv.kotlindsv/ShortRowPolicy = ..., dev.sargunv.kotlindsv/LongRowPolicy = ...): dev.sargunv.kotlindsv/DsvScheme // dev.sargunv.kotlindsv/DsvScheme.copy|copy(kotlin.Char;kotlin.Char;kotlin.Boolean;kotlin.Boolean;dev.sargunv.kotlindsv.ShortRowPolicy;dev.sargunv.kotlindsv.LongRowPolicy){}[0]
+    final fun copy(kotlin/Char = ..., kotlin/Char = ..., dev.sargunv.kotlindsv/RecordDelimiter = ..., kotlin/Boolean = ..., dev.sargunv.kotlindsv/ShortRowPolicy = ..., dev.sargunv.kotlindsv/LongRowPolicy = ...): dev.sargunv.kotlindsv/DsvScheme // dev.sargunv.kotlindsv/DsvScheme.copy|copy(kotlin.Char;kotlin.Char;dev.sargunv.kotlindsv.RecordDelimiter;kotlin.Boolean;dev.sargunv.kotlindsv.ShortRowPolicy;dev.sargunv.kotlindsv.LongRowPolicy){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // dev.sargunv.kotlindsv/DsvScheme.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // dev.sargunv.kotlindsv/DsvScheme.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // dev.sargunv.kotlindsv/DsvScheme.toString|toString(){}[0]
@@ -179,6 +179,42 @@ open class dev.sargunv.kotlindsv/DsvFormat : kotlinx.serialization/SerialFormat 
     final inline fun <#A1: reified kotlin/Any?> decodeFromString(kotlin/String): kotlin.collections/List<#A1> // dev.sargunv.kotlindsv/DsvFormat.decodeFromString|decodeFromString(kotlin.String){0§<kotlin.Any?>}[0]
     final inline fun <#A1: reified kotlin/Any?> encodeToSink(kotlin.sequences/Sequence<#A1>, kotlinx.io/Sink) // dev.sargunv.kotlindsv/DsvFormat.encodeToSink|encodeToSink(kotlin.sequences.Sequence<0:0>;kotlinx.io.Sink){0§<kotlin.Any?>}[0]
     final inline fun <#A1: reified kotlin/Any?> encodeToString(kotlin.collections/List<#A1>): kotlin/String // dev.sargunv.kotlindsv/DsvFormat.encodeToString|encodeToString(kotlin.collections.List<0:0>){0§<kotlin.Any?>}[0]
+}
+
+sealed class dev.sargunv.kotlindsv/RecordDelimiter { // dev.sargunv.kotlindsv/RecordDelimiter|null[0]
+    abstract val value // dev.sargunv.kotlindsv/RecordDelimiter.value|{}value[0]
+        abstract fun <get-value>(): kotlin/String // dev.sargunv.kotlindsv/RecordDelimiter.value.<get-value>|<get-value>(){}[0]
+
+    final class Exact : dev.sargunv.kotlindsv/RecordDelimiter { // dev.sargunv.kotlindsv/RecordDelimiter.Exact|null[0]
+        constructor <init>(kotlin/String) // dev.sargunv.kotlindsv/RecordDelimiter.Exact.<init>|<init>(kotlin.String){}[0]
+
+        final val value // dev.sargunv.kotlindsv/RecordDelimiter.Exact.value|{}value[0]
+            final fun <get-value>(): kotlin/String // dev.sargunv.kotlindsv/RecordDelimiter.Exact.value.<get-value>|<get-value>(){}[0]
+
+        final fun component1(): kotlin/String // dev.sargunv.kotlindsv/RecordDelimiter.Exact.component1|component1(){}[0]
+        final fun copy(kotlin/String = ...): dev.sargunv.kotlindsv/RecordDelimiter.Exact // dev.sargunv.kotlindsv/RecordDelimiter.Exact.copy|copy(kotlin.String){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // dev.sargunv.kotlindsv/RecordDelimiter.Exact.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // dev.sargunv.kotlindsv/RecordDelimiter.Exact.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // dev.sargunv.kotlindsv/RecordDelimiter.Exact.toString|toString(){}[0]
+    }
+
+    final object CrLf : dev.sargunv.kotlindsv/RecordDelimiter { // dev.sargunv.kotlindsv/RecordDelimiter.CrLf|null[0]
+        final val value // dev.sargunv.kotlindsv/RecordDelimiter.CrLf.value|{}value[0]
+            final fun <get-value>(): kotlin/String // dev.sargunv.kotlindsv/RecordDelimiter.CrLf.value.<get-value>|<get-value>(){}[0]
+
+        final fun equals(kotlin/Any?): kotlin/Boolean // dev.sargunv.kotlindsv/RecordDelimiter.CrLf.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // dev.sargunv.kotlindsv/RecordDelimiter.CrLf.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // dev.sargunv.kotlindsv/RecordDelimiter.CrLf.toString|toString(){}[0]
+    }
+
+    final object Lf : dev.sargunv.kotlindsv/RecordDelimiter { // dev.sargunv.kotlindsv/RecordDelimiter.Lf|null[0]
+        final val value // dev.sargunv.kotlindsv/RecordDelimiter.Lf.value|{}value[0]
+            final fun <get-value>(): kotlin/String // dev.sargunv.kotlindsv/RecordDelimiter.Lf.value.<get-value>|<get-value>(){}[0]
+
+        final fun equals(kotlin/Any?): kotlin/Boolean // dev.sargunv.kotlindsv/RecordDelimiter.Lf.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // dev.sargunv.kotlindsv/RecordDelimiter.Lf.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // dev.sargunv.kotlindsv/RecordDelimiter.Lf.toString|toString(){}[0]
+    }
 }
 
 final object dev.sargunv.kotlindsv/Csv : dev.sargunv.kotlindsv/DsvFormat // dev.sargunv.kotlindsv/Csv|null[0]

--- a/kotlin-dsv/api/kotlin-dsv.klib.api
+++ b/kotlin-dsv/api/kotlin-dsv.klib.api
@@ -108,6 +108,42 @@ abstract interface dev.sargunv.kotlindsv/DsvNamingStrategy { // dev.sargunv.kotl
     }
 }
 
+sealed interface dev.sargunv.kotlindsv/RecordDelimiter { // dev.sargunv.kotlindsv/RecordDelimiter|null[0]
+    abstract val value // dev.sargunv.kotlindsv/RecordDelimiter.value|{}value[0]
+        abstract fun <get-value>(): kotlin/String // dev.sargunv.kotlindsv/RecordDelimiter.value.<get-value>|<get-value>(){}[0]
+
+    final class Exact : dev.sargunv.kotlindsv/RecordDelimiter { // dev.sargunv.kotlindsv/RecordDelimiter.Exact|null[0]
+        constructor <init>(kotlin/String) // dev.sargunv.kotlindsv/RecordDelimiter.Exact.<init>|<init>(kotlin.String){}[0]
+
+        final val value // dev.sargunv.kotlindsv/RecordDelimiter.Exact.value|{}value[0]
+            final fun <get-value>(): kotlin/String // dev.sargunv.kotlindsv/RecordDelimiter.Exact.value.<get-value>|<get-value>(){}[0]
+
+        final fun component1(): kotlin/String // dev.sargunv.kotlindsv/RecordDelimiter.Exact.component1|component1(){}[0]
+        final fun copy(kotlin/String = ...): dev.sargunv.kotlindsv/RecordDelimiter.Exact // dev.sargunv.kotlindsv/RecordDelimiter.Exact.copy|copy(kotlin.String){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // dev.sargunv.kotlindsv/RecordDelimiter.Exact.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // dev.sargunv.kotlindsv/RecordDelimiter.Exact.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // dev.sargunv.kotlindsv/RecordDelimiter.Exact.toString|toString(){}[0]
+    }
+
+    final object CrLf : dev.sargunv.kotlindsv/RecordDelimiter { // dev.sargunv.kotlindsv/RecordDelimiter.CrLf|null[0]
+        final val value // dev.sargunv.kotlindsv/RecordDelimiter.CrLf.value|{}value[0]
+            final fun <get-value>(): kotlin/String // dev.sargunv.kotlindsv/RecordDelimiter.CrLf.value.<get-value>|<get-value>(){}[0]
+
+        final fun equals(kotlin/Any?): kotlin/Boolean // dev.sargunv.kotlindsv/RecordDelimiter.CrLf.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // dev.sargunv.kotlindsv/RecordDelimiter.CrLf.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // dev.sargunv.kotlindsv/RecordDelimiter.CrLf.toString|toString(){}[0]
+    }
+
+    final object Lf : dev.sargunv.kotlindsv/RecordDelimiter { // dev.sargunv.kotlindsv/RecordDelimiter.Lf|null[0]
+        final val value // dev.sargunv.kotlindsv/RecordDelimiter.Lf.value|{}value[0]
+            final fun <get-value>(): kotlin/String // dev.sargunv.kotlindsv/RecordDelimiter.Lf.value.<get-value>|<get-value>(){}[0]
+
+        final fun equals(kotlin/Any?): kotlin/Boolean // dev.sargunv.kotlindsv/RecordDelimiter.Lf.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // dev.sargunv.kotlindsv/RecordDelimiter.Lf.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // dev.sargunv.kotlindsv/RecordDelimiter.Lf.toString|toString(){}[0]
+    }
+}
+
 final class dev.sargunv.kotlindsv/DsvParseException : kotlinx.serialization/SerializationException { // dev.sargunv.kotlindsv/DsvParseException|null[0]
     constructor <init>(kotlin/String) // dev.sargunv.kotlindsv/DsvParseException.<init>|<init>(kotlin.String){}[0]
 }
@@ -153,26 +189,6 @@ final class dev.sargunv.kotlindsv/DsvWriter { // dev.sargunv.kotlindsv/DsvWriter
     final fun write(kotlin.collections/List<kotlin.collections/Map<kotlin/String, kotlin/String>>) // dev.sargunv.kotlindsv/DsvWriter.write|write(kotlin.collections.List<kotlin.collections.Map<kotlin.String,kotlin.String>>){}[0]
     final fun write(kotlin.sequences/Sequence<kotlin.collections/List<kotlin/String>>) // dev.sargunv.kotlindsv/DsvWriter.write|write(kotlin.sequences.Sequence<kotlin.collections.List<kotlin.String>>){}[0]
     final fun write(kotlin.sequences/Sequence<kotlin.collections/Map<kotlin/String, kotlin/String>>) // dev.sargunv.kotlindsv/DsvWriter.write|write(kotlin.sequences.Sequence<kotlin.collections.Map<kotlin.String,kotlin.String>>){}[0]
-}
-
-final class dev.sargunv.kotlindsv/RecordDelimiter { // dev.sargunv.kotlindsv/RecordDelimiter|null[0]
-    constructor <init>(kotlin/String, kotlin.collections/List<kotlin/String> = ...) // dev.sargunv.kotlindsv/RecordDelimiter.<init>|<init>(kotlin.String;kotlin.collections.List<kotlin.String>){}[0]
-
-    final val read // dev.sargunv.kotlindsv/RecordDelimiter.read|{}read[0]
-        final fun <get-read>(): kotlin.collections/List<kotlin/String> // dev.sargunv.kotlindsv/RecordDelimiter.read.<get-read>|<get-read>(){}[0]
-    final val write // dev.sargunv.kotlindsv/RecordDelimiter.write|{}write[0]
-        final fun <get-write>(): kotlin/String // dev.sargunv.kotlindsv/RecordDelimiter.write.<get-write>|<get-write>(){}[0]
-
-    final fun equals(kotlin/Any?): kotlin/Boolean // dev.sargunv.kotlindsv/RecordDelimiter.equals|equals(kotlin.Any?){}[0]
-    final fun hashCode(): kotlin/Int // dev.sargunv.kotlindsv/RecordDelimiter.hashCode|hashCode(){}[0]
-    final fun toString(): kotlin/String // dev.sargunv.kotlindsv/RecordDelimiter.toString|toString(){}[0]
-
-    final object Companion { // dev.sargunv.kotlindsv/RecordDelimiter.Companion|null[0]
-        final val CrLf // dev.sargunv.kotlindsv/RecordDelimiter.Companion.CrLf|{}CrLf[0]
-            final fun <get-CrLf>(): dev.sargunv.kotlindsv/RecordDelimiter // dev.sargunv.kotlindsv/RecordDelimiter.Companion.CrLf.<get-CrLf>|<get-CrLf>(){}[0]
-        final val Lf // dev.sargunv.kotlindsv/RecordDelimiter.Companion.Lf|{}Lf[0]
-            final fun <get-Lf>(): dev.sargunv.kotlindsv/RecordDelimiter // dev.sargunv.kotlindsv/RecordDelimiter.Companion.Lf.<get-Lf>|<get-Lf>(){}[0]
-    }
 }
 
 open class dev.sargunv.kotlindsv/DsvFormat : kotlinx.serialization/SerialFormat { // dev.sargunv.kotlindsv/DsvFormat|null[0]

--- a/kotlin-dsv/api/kotlin-dsv.klib.api
+++ b/kotlin-dsv/api/kotlin-dsv.klib.api
@@ -155,6 +155,26 @@ final class dev.sargunv.kotlindsv/DsvWriter { // dev.sargunv.kotlindsv/DsvWriter
     final fun write(kotlin.sequences/Sequence<kotlin.collections/Map<kotlin/String, kotlin/String>>) // dev.sargunv.kotlindsv/DsvWriter.write|write(kotlin.sequences.Sequence<kotlin.collections.Map<kotlin.String,kotlin.String>>){}[0]
 }
 
+final class dev.sargunv.kotlindsv/RecordDelimiter { // dev.sargunv.kotlindsv/RecordDelimiter|null[0]
+    constructor <init>(kotlin/String, kotlin.collections/List<kotlin/String> = ...) // dev.sargunv.kotlindsv/RecordDelimiter.<init>|<init>(kotlin.String;kotlin.collections.List<kotlin.String>){}[0]
+
+    final val read // dev.sargunv.kotlindsv/RecordDelimiter.read|{}read[0]
+        final fun <get-read>(): kotlin.collections/List<kotlin/String> // dev.sargunv.kotlindsv/RecordDelimiter.read.<get-read>|<get-read>(){}[0]
+    final val write // dev.sargunv.kotlindsv/RecordDelimiter.write|{}write[0]
+        final fun <get-write>(): kotlin/String // dev.sargunv.kotlindsv/RecordDelimiter.write.<get-write>|<get-write>(){}[0]
+
+    final fun equals(kotlin/Any?): kotlin/Boolean // dev.sargunv.kotlindsv/RecordDelimiter.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // dev.sargunv.kotlindsv/RecordDelimiter.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // dev.sargunv.kotlindsv/RecordDelimiter.toString|toString(){}[0]
+
+    final object Companion { // dev.sargunv.kotlindsv/RecordDelimiter.Companion|null[0]
+        final val CrLf // dev.sargunv.kotlindsv/RecordDelimiter.Companion.CrLf|{}CrLf[0]
+            final fun <get-CrLf>(): dev.sargunv.kotlindsv/RecordDelimiter // dev.sargunv.kotlindsv/RecordDelimiter.Companion.CrLf.<get-CrLf>|<get-CrLf>(){}[0]
+        final val Lf // dev.sargunv.kotlindsv/RecordDelimiter.Companion.Lf|{}Lf[0]
+            final fun <get-Lf>(): dev.sargunv.kotlindsv/RecordDelimiter // dev.sargunv.kotlindsv/RecordDelimiter.Companion.Lf.<get-Lf>|<get-Lf>(){}[0]
+    }
+}
+
 open class dev.sargunv.kotlindsv/DsvFormat : kotlinx.serialization/SerialFormat { // dev.sargunv.kotlindsv/DsvFormat|null[0]
     constructor <init>(dev.sargunv.kotlindsv/DsvScheme, kotlinx.serialization.modules/SerializersModule = ..., dev.sargunv.kotlindsv/DsvNamingStrategy = ..., kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Boolean = ...) // dev.sargunv.kotlindsv/DsvFormat.<init>|<init>(dev.sargunv.kotlindsv.DsvScheme;kotlinx.serialization.modules.SerializersModule;dev.sargunv.kotlindsv.DsvNamingStrategy;kotlin.Boolean;kotlin.Boolean;kotlin.Boolean){}[0]
 
@@ -179,42 +199,6 @@ open class dev.sargunv.kotlindsv/DsvFormat : kotlinx.serialization/SerialFormat 
     final inline fun <#A1: reified kotlin/Any?> decodeFromString(kotlin/String): kotlin.collections/List<#A1> // dev.sargunv.kotlindsv/DsvFormat.decodeFromString|decodeFromString(kotlin.String){0§<kotlin.Any?>}[0]
     final inline fun <#A1: reified kotlin/Any?> encodeToSink(kotlin.sequences/Sequence<#A1>, kotlinx.io/Sink) // dev.sargunv.kotlindsv/DsvFormat.encodeToSink|encodeToSink(kotlin.sequences.Sequence<0:0>;kotlinx.io.Sink){0§<kotlin.Any?>}[0]
     final inline fun <#A1: reified kotlin/Any?> encodeToString(kotlin.collections/List<#A1>): kotlin/String // dev.sargunv.kotlindsv/DsvFormat.encodeToString|encodeToString(kotlin.collections.List<0:0>){0§<kotlin.Any?>}[0]
-}
-
-sealed class dev.sargunv.kotlindsv/RecordDelimiter { // dev.sargunv.kotlindsv/RecordDelimiter|null[0]
-    abstract val value // dev.sargunv.kotlindsv/RecordDelimiter.value|{}value[0]
-        abstract fun <get-value>(): kotlin/String // dev.sargunv.kotlindsv/RecordDelimiter.value.<get-value>|<get-value>(){}[0]
-
-    final class Exact : dev.sargunv.kotlindsv/RecordDelimiter { // dev.sargunv.kotlindsv/RecordDelimiter.Exact|null[0]
-        constructor <init>(kotlin/String) // dev.sargunv.kotlindsv/RecordDelimiter.Exact.<init>|<init>(kotlin.String){}[0]
-
-        final val value // dev.sargunv.kotlindsv/RecordDelimiter.Exact.value|{}value[0]
-            final fun <get-value>(): kotlin/String // dev.sargunv.kotlindsv/RecordDelimiter.Exact.value.<get-value>|<get-value>(){}[0]
-
-        final fun component1(): kotlin/String // dev.sargunv.kotlindsv/RecordDelimiter.Exact.component1|component1(){}[0]
-        final fun copy(kotlin/String = ...): dev.sargunv.kotlindsv/RecordDelimiter.Exact // dev.sargunv.kotlindsv/RecordDelimiter.Exact.copy|copy(kotlin.String){}[0]
-        final fun equals(kotlin/Any?): kotlin/Boolean // dev.sargunv.kotlindsv/RecordDelimiter.Exact.equals|equals(kotlin.Any?){}[0]
-        final fun hashCode(): kotlin/Int // dev.sargunv.kotlindsv/RecordDelimiter.Exact.hashCode|hashCode(){}[0]
-        final fun toString(): kotlin/String // dev.sargunv.kotlindsv/RecordDelimiter.Exact.toString|toString(){}[0]
-    }
-
-    final object CrLf : dev.sargunv.kotlindsv/RecordDelimiter { // dev.sargunv.kotlindsv/RecordDelimiter.CrLf|null[0]
-        final val value // dev.sargunv.kotlindsv/RecordDelimiter.CrLf.value|{}value[0]
-            final fun <get-value>(): kotlin/String // dev.sargunv.kotlindsv/RecordDelimiter.CrLf.value.<get-value>|<get-value>(){}[0]
-
-        final fun equals(kotlin/Any?): kotlin/Boolean // dev.sargunv.kotlindsv/RecordDelimiter.CrLf.equals|equals(kotlin.Any?){}[0]
-        final fun hashCode(): kotlin/Int // dev.sargunv.kotlindsv/RecordDelimiter.CrLf.hashCode|hashCode(){}[0]
-        final fun toString(): kotlin/String // dev.sargunv.kotlindsv/RecordDelimiter.CrLf.toString|toString(){}[0]
-    }
-
-    final object Lf : dev.sargunv.kotlindsv/RecordDelimiter { // dev.sargunv.kotlindsv/RecordDelimiter.Lf|null[0]
-        final val value // dev.sargunv.kotlindsv/RecordDelimiter.Lf.value|{}value[0]
-            final fun <get-value>(): kotlin/String // dev.sargunv.kotlindsv/RecordDelimiter.Lf.value.<get-value>|<get-value>(){}[0]
-
-        final fun equals(kotlin/Any?): kotlin/Boolean // dev.sargunv.kotlindsv/RecordDelimiter.Lf.equals|equals(kotlin.Any?){}[0]
-        final fun hashCode(): kotlin/Int // dev.sargunv.kotlindsv/RecordDelimiter.Lf.hashCode|hashCode(){}[0]
-        final fun toString(): kotlin/String // dev.sargunv.kotlindsv/RecordDelimiter.Lf.toString|toString(){}[0]
-    }
 }
 
 final object dev.sargunv.kotlindsv/Csv : dev.sargunv.kotlindsv/DsvFormat // dev.sargunv.kotlindsv/Csv|null[0]

--- a/kotlin-dsv/src/commonMain/kotlin/dev/sargunv/kotlindsv/DsvParser.kt
+++ b/kotlin-dsv/src/commonMain/kotlin/dev/sargunv/kotlindsv/DsvParser.kt
@@ -92,11 +92,9 @@ public class DsvParser(private val input: Source, private val scheme: DsvScheme)
 
     while (true) {
       val c = charAt(cursor) ?: break
-      when (c) {
-        scheme.quote -> throw DsvParseException("Unexpected quote in non-quoted field")
-        scheme.delimiter,
-        scheme.lineFeed,
-        scheme.carriageReturn -> break
+      when {
+        c == scheme.quote -> throw DsvParseException("Unexpected quote in non-quoted field")
+        c == scheme.delimiter || atRecordBoundary(cursor) -> break
         else -> result.append(c)
       }
       cursor++
@@ -116,35 +114,62 @@ public class DsvParser(private val input: Source, private val scheme: DsvScheme)
 
     while (true) {
       val c = charAt(cursor) ?: break
-      when (c) {
-        scheme.carriageReturn,
-        scheme.lineFeed -> break
-        scheme.delimiter -> {
+      when {
+        atRecordBoundary(cursor) -> break
+        c == scheme.delimiter -> {
           cursor++
           val fieldResult = readNonEmptyField(cursor) ?: ReadResult("", cursor)
           fields.add(fieldResult.value)
           cursor = fieldResult.newPos
         }
-        else -> throw DsvParseException("Expected delimiter or end of line, got $c")
+        else -> throw DsvParseException("Expected delimiter or end of record, got $c")
       }
     }
 
     return ReadResult(fields, cursor)
   }
 
-  private fun readEndOfLine(pos: Int): ReadResult<Unit>? {
-    var c = charAt(pos) ?: return ReadResult(Unit, pos)
-    var pos = pos
+  private fun atRecordBoundary(pos: Int): Boolean {
+    val c = charAt(pos) ?: return false
+    return when (val delimiter = scheme.recordDelimiter) {
+      RecordDelimiter.Lf,
+      RecordDelimiter.CrLf -> c == '\n' || c == '\r'
+      is RecordDelimiter.Exact -> matchesLiteral(pos, delimiter.value)
+    }
+  }
+
+  private fun matchesLiteral(pos: Int, value: String): Boolean {
+    for (i in value.indices) {
+      if (charAt(pos + i) != value[i]) return false
+    }
+    return true
+  }
+
+  private fun readEndOfRecord(pos: Int): ReadResult<Unit>? {
+    if (charAt(pos) == null) return ReadResult(Unit, pos)
+    return when (val delimiter = scheme.recordDelimiter) {
+      RecordDelimiter.Lf,
+      RecordDelimiter.CrLf -> readConventionalNewline(pos)
+      is RecordDelimiter.Exact -> {
+        if (!matchesLiteral(pos, delimiter.value)) null
+        else ReadResult(Unit, pos + delimiter.value.length)
+      }
+    }
+  }
+
+  private fun readConventionalNewline(pos: Int): ReadResult<Unit>? {
+    var cursor = pos
+    var c = charAt(cursor) ?: return ReadResult(Unit, cursor)
 
     while (true) {
       // eat: \r*\n
       // because CRCRLF is apparently a thing
       when (c) {
-        scheme.lineFeed -> return ReadResult(Unit, pos + 1)
-        scheme.carriageReturn -> pos += 1
+        '\n' -> return ReadResult(Unit, cursor + 1)
+        '\r' -> cursor += 1
         else -> return null
       }
-      c = charAt(pos) ?: return ReadResult(Unit, pos)
+      c = charAt(cursor) ?: return ReadResult(Unit, cursor)
     }
   }
 
@@ -165,8 +190,8 @@ public class DsvParser(private val input: Source, private val scheme: DsvScheme)
         val (record, newPos) = readRecord(cursor) ?: break
 
         cursor =
-          readEndOfLine(newPos)?.newPos
-            ?: throw DsvParseException("Expected end of line, got '${charAt(newPos)}'")
+          readEndOfRecord(newPos)?.newPos
+            ?: throw DsvParseException("Expected end of record, got '${charAt(newPos)}'")
         data = StringBuilder(data.drop(cursor))
         cursor = 0
 

--- a/kotlin-dsv/src/commonMain/kotlin/dev/sargunv/kotlindsv/DsvParser.kt
+++ b/kotlin-dsv/src/commonMain/kotlin/dev/sargunv/kotlindsv/DsvParser.kt
@@ -220,6 +220,5 @@ public class DsvParser(private val input: Source, private val scheme: DsvScheme)
 
   private companion object {
     private const val MAX_UTF8_INCOMPLETE_BYTES = 3
-    private const val UTF8_BOM = '\uFEFF'
   }
 }

--- a/kotlin-dsv/src/commonMain/kotlin/dev/sargunv/kotlindsv/DsvParser.kt
+++ b/kotlin-dsv/src/commonMain/kotlin/dev/sargunv/kotlindsv/DsvParser.kt
@@ -129,48 +129,15 @@ public class DsvParser(private val input: Source, private val scheme: DsvScheme)
     return ReadResult(fields, cursor)
   }
 
-  private fun atRecordBoundary(pos: Int): Boolean {
-    val c = charAt(pos) ?: return false
-    return when (val delimiter = scheme.recordDelimiter) {
-      RecordDelimiter.Lf,
-      RecordDelimiter.CrLf -> c == '\n' || c == '\r'
-      is RecordDelimiter.Exact -> matchesLiteral(pos, delimiter.value)
-    }
-  }
+  private fun matchRecordDelimiter(pos: Int): Int? =
+    scheme.recordDelimiter.matchLength(::charAt, pos)
 
-  private fun matchesLiteral(pos: Int, value: String): Boolean {
-    for (i in value.indices) {
-      if (charAt(pos + i) != value[i]) return false
-    }
-    return true
-  }
+  private fun atRecordBoundary(pos: Int): Boolean = matchRecordDelimiter(pos) != null
 
   private fun readEndOfRecord(pos: Int): ReadResult<Unit>? {
     if (charAt(pos) == null) return ReadResult(Unit, pos)
-    return when (val delimiter = scheme.recordDelimiter) {
-      RecordDelimiter.Lf,
-      RecordDelimiter.CrLf -> readConventionalNewline(pos)
-      is RecordDelimiter.Exact -> {
-        if (!matchesLiteral(pos, delimiter.value)) null
-        else ReadResult(Unit, pos + delimiter.value.length)
-      }
-    }
-  }
-
-  private fun readConventionalNewline(pos: Int): ReadResult<Unit>? {
-    var cursor = pos
-    var c = charAt(cursor) ?: return ReadResult(Unit, cursor)
-
-    while (true) {
-      // eat: \r*\n
-      // because CRCRLF is apparently a thing
-      when (c) {
-        '\n' -> return ReadResult(Unit, cursor + 1)
-        '\r' -> cursor += 1
-        else -> return null
-      }
-      c = charAt(cursor) ?: return ReadResult(Unit, cursor)
-    }
+    val length = matchRecordDelimiter(pos) ?: return null
+    return ReadResult(Unit, pos + length)
   }
 
   /**

--- a/kotlin-dsv/src/commonMain/kotlin/dev/sargunv/kotlindsv/DsvScheme.kt
+++ b/kotlin-dsv/src/commonMain/kotlin/dev/sargunv/kotlindsv/DsvScheme.kt
@@ -7,7 +7,7 @@ import kotlin.jvm.JvmOverloads
  *
  * @property delimiter The character used to separate fields (e.g., ',' for CSV, '\t' for TSV).
  * @property quote The character used to quote fields containing special characters.
- * @property writeCrlf When true, writes CRLF line endings; otherwise uses LF.
+ * @property recordDelimiter How records are terminated when reading and writing.
  * @property skipEmptyLines When true, empty lines in the input are skipped during parsing.
  * @property shortRowPolicy How later rows with fewer fields than the first kept row are handled.
  * @property longRowPolicy How later rows with more fields than the first kept row are handled.
@@ -17,22 +17,16 @@ public data class DsvScheme
 constructor(
   internal val delimiter: Char,
   internal val quote: Char = '"',
-  internal val writeCrlf: Boolean = true,
+  internal val recordDelimiter: RecordDelimiter = RecordDelimiter.CrLf,
   internal val skipEmptyLines: Boolean = false,
   internal val shortRowPolicy: ShortRowPolicy = ShortRowPolicy.Reject,
   internal val longRowPolicy: LongRowPolicy = LongRowPolicy.Reject,
 ) {
-  // line delimiters prob shouldn't be configurable
-  internal val lineFeed: Char = '\n'
-  internal val carriageReturn: Char = '\r'
-
   init {
     require(quote != delimiter) { "Quote and delimiter must be different characters" }
-    require(quote != lineFeed && quote != carriageReturn) {
-      "Quote must not be a newline character"
-    }
-    require(delimiter != lineFeed && delimiter != carriageReturn) {
-      "Delimiter must not be a newline character"
+    require(quote !in recordDelimiter.value) { "Quote must not appear in the record delimiter" }
+    require(delimiter !in recordDelimiter.value) {
+      "Delimiter must not appear in the record delimiter"
     }
   }
 }

--- a/kotlin-dsv/src/commonMain/kotlin/dev/sargunv/kotlindsv/DsvScheme.kt
+++ b/kotlin-dsv/src/commonMain/kotlin/dev/sargunv/kotlindsv/DsvScheme.kt
@@ -24,8 +24,10 @@ constructor(
 ) {
   init {
     require(quote != delimiter) { "Quote and delimiter must be different characters" }
-    require(quote !in recordDelimiter.value) { "Quote must not appear in the record delimiter" }
-    require(delimiter !in recordDelimiter.value) {
+    require(recordDelimiter.strings().none { quote in it }) {
+      "Quote must not appear in the record delimiter"
+    }
+    require(recordDelimiter.strings().none { delimiter in it }) {
       "Delimiter must not appear in the record delimiter"
     }
   }

--- a/kotlin-dsv/src/commonMain/kotlin/dev/sargunv/kotlindsv/DsvScheme.kt
+++ b/kotlin-dsv/src/commonMain/kotlin/dev/sargunv/kotlindsv/DsvScheme.kt
@@ -24,10 +24,10 @@ constructor(
 ) {
   init {
     require(quote != delimiter) { "Quote and delimiter must be different characters" }
-    require(recordDelimiter.strings().none { quote in it }) {
+    require(recordDelimiter.quoteNeedles().none { quote in it }) {
       "Quote must not appear in the record delimiter"
     }
-    require(recordDelimiter.strings().none { delimiter in it }) {
+    require(recordDelimiter.quoteNeedles().none { delimiter in it }) {
       "Delimiter must not appear in the record delimiter"
     }
   }

--- a/kotlin-dsv/src/commonMain/kotlin/dev/sargunv/kotlindsv/DsvWriter.kt
+++ b/kotlin-dsv/src/commonMain/kotlin/dev/sargunv/kotlindsv/DsvWriter.kt
@@ -19,7 +19,7 @@ public class DsvWriter(private val sink: Sink, private val scheme: DsvScheme) {
 
   private fun fieldNeedsQuoting(field: String): Boolean {
     if (field.any { it == scheme.delimiter || it == scheme.quote }) return true
-    return scheme.recordDelimiter.strings().any { field.contains(it) }
+    return scheme.recordDelimiter.quoteNeedles().any { field.contains(it) }
   }
 
   private fun writeField(field: String) =
@@ -47,7 +47,7 @@ public class DsvWriter(private val sink: Sink, private val scheme: DsvScheme) {
       writeField(field)
     }
 
-    sink.writeString(scheme.recordDelimiter.write)
+    sink.writeString(scheme.recordDelimiter.value)
   }
 
   /** Writes a [DsvTable] including its header row. */

--- a/kotlin-dsv/src/commonMain/kotlin/dev/sargunv/kotlindsv/DsvWriter.kt
+++ b/kotlin-dsv/src/commonMain/kotlin/dev/sargunv/kotlindsv/DsvWriter.kt
@@ -17,15 +17,17 @@ public class DsvWriter(private val sink: Sink, private val scheme: DsvScheme) {
 
   private fun Sink.writeChar(c: Char) = writeString(c.toString())
 
+  private fun fieldNeedsQuoting(field: String): Boolean {
+    if (field.any { it == scheme.delimiter || it == scheme.quote }) return true
+    return when (val delimiter = scheme.recordDelimiter) {
+      RecordDelimiter.Lf,
+      RecordDelimiter.CrLf -> field.any { it == '\n' || it == '\r' }
+      is RecordDelimiter.Exact -> field.contains(delimiter.value)
+    }
+  }
+
   private fun writeField(field: String) =
-    if (
-      field.any {
-        it == scheme.delimiter ||
-          it == scheme.quote ||
-          it == scheme.lineFeed ||
-          it == scheme.carriageReturn
-      }
-    ) {
+    if (fieldNeedsQuoting(field)) {
       sink.writeChar(scheme.quote)
       sink.writeString(
         field.replace(scheme.quote.toString(), scheme.quote.toString() + scheme.quote)
@@ -49,8 +51,7 @@ public class DsvWriter(private val sink: Sink, private val scheme: DsvScheme) {
       writeField(field)
     }
 
-    if (scheme.writeCrlf) sink.writeChar(scheme.carriageReturn)
-    sink.writeChar(scheme.lineFeed)
+    sink.writeString(scheme.recordDelimiter.value)
   }
 
   /** Writes a [DsvTable] including its header row. */

--- a/kotlin-dsv/src/commonMain/kotlin/dev/sargunv/kotlindsv/DsvWriter.kt
+++ b/kotlin-dsv/src/commonMain/kotlin/dev/sargunv/kotlindsv/DsvWriter.kt
@@ -19,11 +19,7 @@ public class DsvWriter(private val sink: Sink, private val scheme: DsvScheme) {
 
   private fun fieldNeedsQuoting(field: String): Boolean {
     if (field.any { it == scheme.delimiter || it == scheme.quote }) return true
-    return when (val delimiter = scheme.recordDelimiter) {
-      RecordDelimiter.Lf,
-      RecordDelimiter.CrLf -> field.any { it == '\n' || it == '\r' }
-      is RecordDelimiter.Exact -> field.contains(delimiter.value)
-    }
+    return scheme.recordDelimiter.strings().any { field.contains(it) }
   }
 
   private fun writeField(field: String) =
@@ -51,7 +47,7 @@ public class DsvWriter(private val sink: Sink, private val scheme: DsvScheme) {
       writeField(field)
     }
 
-    sink.writeString(scheme.recordDelimiter.value)
+    sink.writeString(scheme.recordDelimiter.write)
   }
 
   /** Writes a [DsvTable] including its header row. */

--- a/kotlin-dsv/src/commonMain/kotlin/dev/sargunv/kotlindsv/DsvWriter.kt
+++ b/kotlin-dsv/src/commonMain/kotlin/dev/sargunv/kotlindsv/DsvWriter.kt
@@ -17,13 +17,14 @@ public class DsvWriter(private val sink: Sink, private val scheme: DsvScheme) {
 
   private fun Sink.writeChar(c: Char) = writeString(c.toString())
 
-  private fun fieldNeedsQuoting(field: String): Boolean {
+  private fun fieldNeedsQuoting(field: String, lastField: Boolean): Boolean {
     if (field.any { it == scheme.delimiter || it == scheme.quote }) return true
-    return scheme.recordDelimiter.quoteNeedles().any { field.contains(it) }
+    if (scheme.recordDelimiter.quoteNeedles().any { field.contains(it) }) return true
+    return lastField && scheme.recordDelimiter.suffixOverlapsWriteValue(field)
   }
 
-  private fun writeField(field: String) =
-    if (fieldNeedsQuoting(field)) {
+  private fun writeField(field: String, lastField: Boolean) =
+    if (fieldNeedsQuoting(field, lastField)) {
       sink.writeChar(scheme.quote)
       sink.writeString(
         field.replace(scheme.quote.toString(), scheme.quote.toString() + scheme.quote)
@@ -44,7 +45,7 @@ public class DsvWriter(private val sink: Sink, private val scheme: DsvScheme) {
 
     record.forEachIndexed { i, field ->
       if (i > 0) sink.writeChar(scheme.delimiter)
-      writeField(field)
+      writeField(field, lastField = i == record.lastIndex)
     }
 
     sink.writeString(scheme.recordDelimiter.value)

--- a/kotlin-dsv/src/commonMain/kotlin/dev/sargunv/kotlindsv/RecordDelimiter.kt
+++ b/kotlin-dsv/src/commonMain/kotlin/dev/sargunv/kotlindsv/RecordDelimiter.kt
@@ -8,15 +8,25 @@ import kotlin.jvm.JvmOverloads
  * [write] is emitted after every record. [read] is the set of strings that terminate a record when
  * parsing. Matching uses the longest [read] string at the current position.
  *
- * [Lf] and [CrLf] write that newline and read LF, CRLF, and CRCRLF. A single-string constructor
- * such as `RecordDelimiter("\n%%\n")` reads and writes that string exactly.
+ * [Lf] and [CrLf] write that newline and, when reading, accept `\r*\n` (any number of CR bytes
+ * before LF, including CRCRLF). A single-string constructor such as `RecordDelimiter("\n%%\n")`
+ * reads and writes that string exactly.
  *
  * @property write String written after each record.
  * @property read Strings accepted as a record terminator when reading.
  */
 public class RecordDelimiter
-@JvmOverloads
-constructor(write: String, read: List<String> = listOf(write)) {
+private constructor(
+  write: String,
+  read: List<String>,
+  private val acceptCrStarLf: Boolean,
+) {
+  @JvmOverloads
+  public constructor(
+    write: String,
+    read: List<String> = listOf(write),
+  ) : this(write, read, acceptCrStarLf = false)
+
   public val write: String = write
   public val read: List<String> = read.toList()
 
@@ -32,6 +42,7 @@ constructor(write: String, read: List<String> = listOf(write)) {
   }
 
   internal fun matchLength(charAt: (Int) -> Char?, pos: Int): Int? {
+    if (acceptCrStarLf) return matchCrStarLf(charAt, pos)
     if (charAt(pos) !in heads) return null
     for (token in tokens) {
       if (matchesLiteral(charAt, pos, token)) return token.length
@@ -40,26 +51,51 @@ constructor(write: String, read: List<String> = listOf(write)) {
   }
 
   override fun equals(other: Any?): Boolean =
-    other is RecordDelimiter && write == other.write && tokens.toSet() == other.tokens.toSet()
+    other is RecordDelimiter &&
+      write == other.write &&
+      tokens.toSet() == other.tokens.toSet() &&
+      acceptCrStarLf == other.acceptCrStarLf
 
-  override fun hashCode(): Int = 31 * write.hashCode() + tokens.toSet().hashCode()
+  override fun hashCode(): Int =
+    31 * (31 * write.hashCode() + tokens.toSet().hashCode()) + acceptCrStarLf.hashCode()
 
-  override fun toString(): String = "RecordDelimiter(write=$write, read=$read)"
+  override fun toString(): String =
+    if (acceptCrStarLf) "RecordDelimiter(write=$write, read=\\r*\\n)"
+    else "RecordDelimiter(write=$write, read=$read)"
 
   internal fun strings(): Sequence<String> = sequence {
     yield(write)
     yieldAll(read)
+    if (acceptCrStarLf) yield("\r")
   }
 
   /** Built-in newline delimiters. */
   public companion object {
-    private val conventionalNewlines: List<String> = listOf("\r\r\n", "\r\n", "\n")
+    private val lfAndCrlf: List<String> = listOf("\r\n", "\n")
 
-    /** Writes LF. Reading accepts LF, CRLF, and CRCRLF. */
-    public val Lf: RecordDelimiter = RecordDelimiter(write = "\n", read = conventionalNewlines)
+    /** Writes LF. Reading accepts `\r*\n`. */
+    public val Lf: RecordDelimiter = RecordDelimiter("\n", lfAndCrlf, acceptCrStarLf = true)
 
-    /** Writes CRLF. Reading accepts LF, CRLF, and CRCRLF. */
-    public val CrLf: RecordDelimiter = RecordDelimiter(write = "\r\n", read = conventionalNewlines)
+    /** Writes CRLF. Reading accepts `\r*\n`. */
+    public val CrLf: RecordDelimiter = RecordDelimiter("\r\n", lfAndCrlf, acceptCrStarLf = true)
+  }
+}
+
+private fun matchCrStarLf(charAt: (Int) -> Char?, pos: Int): Int? {
+  var cursor = pos
+  var consumed = 0
+  var c = charAt(cursor) ?: return null
+
+  while (true) {
+    when (c) {
+      '\n' -> return consumed + 1
+      '\r' -> {
+        consumed += 1
+        cursor += 1
+      }
+      else -> return null
+    }
+    c = charAt(cursor) ?: return consumed
   }
 }
 

--- a/kotlin-dsv/src/commonMain/kotlin/dev/sargunv/kotlindsv/RecordDelimiter.kt
+++ b/kotlin-dsv/src/commonMain/kotlin/dev/sargunv/kotlindsv/RecordDelimiter.kt
@@ -23,11 +23,12 @@ public sealed interface RecordDelimiter {
   /**
    * Writes and reads [value] exactly.
    *
-   * @throws IllegalArgumentException if [value] is empty.
+   * @throws IllegalArgumentException if [value] is empty or starts with U+FEFF.
    */
   public data class Exact(override val value: String) : RecordDelimiter {
     init {
       require(value.isNotEmpty()) { "Record delimiter must not be empty" }
+      require(value.first() != UTF8_BOM) { "Record delimiter must not start with a BOM" }
     }
   }
 }
@@ -45,6 +46,11 @@ internal fun RecordDelimiter.quoteNeedles(): Sequence<String> =
     RecordDelimiter.CrLf -> sequenceOf("\n", "\r")
     is RecordDelimiter.Exact -> sequenceOf(value)
   }
+
+internal fun RecordDelimiter.suffixOverlapsWriteValue(field: String): Boolean =
+  (field + value).indexOf(value) < field.length
+
+internal const val UTF8_BOM = '\uFEFF'
 
 private fun matchCrStarLf(charAt: (Int) -> Char?, pos: Int): Int? {
   var cursor = pos

--- a/kotlin-dsv/src/commonMain/kotlin/dev/sargunv/kotlindsv/RecordDelimiter.kt
+++ b/kotlin-dsv/src/commonMain/kotlin/dev/sargunv/kotlindsv/RecordDelimiter.kt
@@ -1,34 +1,71 @@
 package dev.sargunv.kotlindsv
 
+import kotlin.jvm.JvmOverloads
+
 /**
  * Separates records in a [DSV][DsvFormat] document.
  *
- * [Lf] and [CrLf] write that newline and, when reading, accept LF, CRLF, and extra CR bytes before
- * LF (including CRCRLF). [Exact] writes and reads one specific string, including multi-character
- * warehouse separators such as `\n%%\n`.
+ * [write] is emitted after every record. [read] is the set of strings that terminate a record when
+ * parsing. Matching uses the longest [read] string at the current position.
+ *
+ * [Lf] and [CrLf] write that newline and read LF, CRLF, and CRCRLF. A single-string constructor
+ * such as `RecordDelimiter("\n%%\n")` reads and writes that string exactly.
+ *
+ * @property write String written after each record.
+ * @property read Strings accepted as a record terminator when reading.
  */
-public sealed class RecordDelimiter {
-  /** String written after each record. */
-  public abstract val value: String
+public class RecordDelimiter
+@JvmOverloads
+constructor(write: String, read: List<String> = listOf(write)) {
+  public val write: String = write
+  public val read: List<String> = read.toList()
 
-  /** Writes LF. Reading accepts conventional newline forms. */
-  public data object Lf : RecordDelimiter() {
-    override val value: String = "\n"
+  internal val tokens: List<String>
+  internal val heads: Set<Char>
+
+  init {
+    require(write.isNotEmpty()) { "Record delimiter write string must not be empty" }
+    require(this.read.isNotEmpty()) { "Record delimiter must accept at least one read string" }
+    require(this.read.all { it.isNotEmpty() }) { "Record delimiter read strings must not be empty" }
+    tokens = this.read.distinct().sortedByDescending { it.length }
+    heads = tokens.mapTo(mutableSetOf()) { it.first() }
   }
 
-  /** Writes CRLF. Reading accepts conventional newline forms. */
-  public data object CrLf : RecordDelimiter() {
-    override val value: String = "\r\n"
-  }
-
-  /**
-   * Writes and reads [value] exactly.
-   *
-   * @throws IllegalArgumentException if [value] is empty.
-   */
-  public data class Exact(override val value: String) : RecordDelimiter() {
-    init {
-      require(value.isNotEmpty()) { "Record delimiter must not be empty" }
+  internal fun matchLength(charAt: (Int) -> Char?, pos: Int): Int? {
+    if (charAt(pos) !in heads) return null
+    for (token in tokens) {
+      if (matchesLiteral(charAt, pos, token)) return token.length
     }
+    return null
   }
+
+  override fun equals(other: Any?): Boolean =
+    other is RecordDelimiter && write == other.write && tokens.toSet() == other.tokens.toSet()
+
+  override fun hashCode(): Int = 31 * write.hashCode() + tokens.toSet().hashCode()
+
+  override fun toString(): String = "RecordDelimiter(write=$write, read=$read)"
+
+  internal fun strings(): Sequence<String> = sequence {
+    yield(write)
+    yieldAll(read)
+  }
+
+  /** Built-in newline delimiters. */
+  public companion object {
+    private val conventionalNewlines: List<String> = listOf("\r\r\n", "\r\n", "\n")
+
+    /** Writes LF. Reading accepts LF, CRLF, and CRCRLF. */
+    public val Lf: RecordDelimiter = RecordDelimiter(write = "\n", read = conventionalNewlines)
+
+    /** Writes CRLF. Reading accepts LF, CRLF, and CRCRLF. */
+    public val CrLf: RecordDelimiter = RecordDelimiter(write = "\r\n", read = conventionalNewlines)
+  }
+}
+
+private fun matchesLiteral(charAt: (Int) -> Char?, pos: Int, value: String): Boolean {
+  for (i in value.indices) {
+    if (charAt(pos + i) != value[i]) return false
+  }
+  return true
 }

--- a/kotlin-dsv/src/commonMain/kotlin/dev/sargunv/kotlindsv/RecordDelimiter.kt
+++ b/kotlin-dsv/src/commonMain/kotlin/dev/sargunv/kotlindsv/RecordDelimiter.kt
@@ -1,0 +1,34 @@
+package dev.sargunv.kotlindsv
+
+/**
+ * Separates records in a [DSV][DsvFormat] document.
+ *
+ * [Lf] and [CrLf] write that newline and, when reading, accept LF, CRLF, and extra CR bytes before
+ * LF (including CRCRLF). [Exact] writes and reads one specific string, including multi-character
+ * warehouse separators such as `\n%%\n`.
+ */
+public sealed class RecordDelimiter {
+  /** String written after each record. */
+  public abstract val value: String
+
+  /** Writes LF. Reading accepts conventional newline forms. */
+  public data object Lf : RecordDelimiter() {
+    override val value: String = "\n"
+  }
+
+  /** Writes CRLF. Reading accepts conventional newline forms. */
+  public data object CrLf : RecordDelimiter() {
+    override val value: String = "\r\n"
+  }
+
+  /**
+   * Writes and reads [value] exactly.
+   *
+   * @throws IllegalArgumentException if [value] is empty.
+   */
+  public data class Exact(override val value: String) : RecordDelimiter() {
+    init {
+      require(value.isNotEmpty()) { "Record delimiter must not be empty" }
+    }
+  }
+}

--- a/kotlin-dsv/src/commonMain/kotlin/dev/sargunv/kotlindsv/RecordDelimiter.kt
+++ b/kotlin-dsv/src/commonMain/kotlin/dev/sargunv/kotlindsv/RecordDelimiter.kt
@@ -1,85 +1,50 @@
 package dev.sargunv.kotlindsv
 
-import kotlin.jvm.JvmOverloads
-
 /**
  * Separates records in a [DSV][DsvFormat] document.
  *
- * [write] is emitted after every record. [read] is the set of strings that terminate a record when
- * parsing. Matching uses the longest [read] string at the current position.
- *
  * [Lf] and [CrLf] write that newline and, when reading, accept `\r*\n` (any number of CR bytes
- * before LF, including CRCRLF). A single-string constructor such as `RecordDelimiter("\n%%\n")`
- * reads and writes that string exactly.
- *
- * @property write String written after each record.
- * @property read Strings accepted as a record terminator when reading.
+ * before LF, including CRCRLF). [Exact] writes and reads one specific string.
  */
-public class RecordDelimiter
-private constructor(
-  write: String,
-  read: List<String>,
-  private val acceptCrStarLf: Boolean,
-) {
-  @JvmOverloads
-  public constructor(
-    write: String,
-    read: List<String> = listOf(write),
-  ) : this(write, read, acceptCrStarLf = false)
+public sealed interface RecordDelimiter {
+  /** String written after each record. */
+  public val value: String
 
-  public val write: String = write
-  public val read: List<String> = read.toList()
-
-  internal val tokens: List<String>
-  internal val heads: Set<Char>
-
-  init {
-    require(write.isNotEmpty()) { "Record delimiter write string must not be empty" }
-    require(this.read.isNotEmpty()) { "Record delimiter must accept at least one read string" }
-    require(this.read.all { it.isNotEmpty() }) { "Record delimiter read strings must not be empty" }
-    tokens = this.read.distinct().sortedByDescending { it.length }
-    heads = tokens.mapTo(mutableSetOf()) { it.first() }
+  /** Writes LF. Reading accepts `\r*\n`. */
+  public data object Lf : RecordDelimiter {
+    override val value: String = "\n"
   }
 
-  internal fun matchLength(charAt: (Int) -> Char?, pos: Int): Int? {
-    if (acceptCrStarLf) return matchCrStarLf(charAt, pos)
-    if (charAt(pos) !in heads) return null
-    for (token in tokens) {
-      if (matchesLiteral(charAt, pos, token)) return token.length
+  /** Writes CRLF. Reading accepts `\r*\n`. */
+  public data object CrLf : RecordDelimiter {
+    override val value: String = "\r\n"
+  }
+
+  /**
+   * Writes and reads [value] exactly.
+   *
+   * @throws IllegalArgumentException if [value] is empty.
+   */
+  public data class Exact(override val value: String) : RecordDelimiter {
+    init {
+      require(value.isNotEmpty()) { "Record delimiter must not be empty" }
     }
-    return null
-  }
-
-  override fun equals(other: Any?): Boolean =
-    other is RecordDelimiter &&
-      write == other.write &&
-      tokens.toSet() == other.tokens.toSet() &&
-      acceptCrStarLf == other.acceptCrStarLf
-
-  override fun hashCode(): Int =
-    31 * (31 * write.hashCode() + tokens.toSet().hashCode()) + acceptCrStarLf.hashCode()
-
-  override fun toString(): String =
-    if (acceptCrStarLf) "RecordDelimiter(write=$write, read=\\r*\\n)"
-    else "RecordDelimiter(write=$write, read=$read)"
-
-  internal fun strings(): Sequence<String> = sequence {
-    yield(write)
-    yieldAll(read)
-    if (acceptCrStarLf) yield("\r")
-  }
-
-  /** Built-in newline delimiters. */
-  public companion object {
-    private val lfAndCrlf: List<String> = listOf("\r\n", "\n")
-
-    /** Writes LF. Reading accepts `\r*\n`. */
-    public val Lf: RecordDelimiter = RecordDelimiter("\n", lfAndCrlf, acceptCrStarLf = true)
-
-    /** Writes CRLF. Reading accepts `\r*\n`. */
-    public val CrLf: RecordDelimiter = RecordDelimiter("\r\n", lfAndCrlf, acceptCrStarLf = true)
   }
 }
+
+internal fun RecordDelimiter.matchLength(charAt: (Int) -> Char?, pos: Int): Int? =
+  when (this) {
+    RecordDelimiter.Lf,
+    RecordDelimiter.CrLf -> matchCrStarLf(charAt, pos)
+    is RecordDelimiter.Exact -> if (matchesLiteral(charAt, pos, value)) value.length else null
+  }
+
+internal fun RecordDelimiter.quoteNeedles(): Sequence<String> =
+  when (this) {
+    RecordDelimiter.Lf,
+    RecordDelimiter.CrLf -> sequenceOf("\n", "\r")
+    is RecordDelimiter.Exact -> sequenceOf(value)
+  }
 
 private fun matchCrStarLf(charAt: (Int) -> Char?, pos: Int): Int? {
   var cursor = pos

--- a/kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/DocsTest.kt
+++ b/kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/DocsTest.kt
@@ -223,9 +223,7 @@ class DocsTest {
 
     // --8<-- [start:custom-record-delimiter]
     val mysqlOutfile =
-      DsvFormat(
-        scheme = DsvScheme(delimiter = ',', recordDelimiter = RecordDelimiter.Exact("\n%%\n"))
-      )
+      DsvFormat(scheme = DsvScheme(delimiter = ',', recordDelimiter = RecordDelimiter("\n%%\n")))
 
     val dumped = mysqlOutfile.encodeToString(rows)
     val decoded = mysqlOutfile.decodeFromString<Row>(dumped)

--- a/kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/DocsTest.kt
+++ b/kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/DocsTest.kt
@@ -209,10 +209,29 @@ class DocsTest {
           DsvScheme(
             delimiter = ';',
             quote = '\'',
-            writeCrlf = false, // Use Unix-style line endings
+            recordDelimiter = RecordDelimiter.Lf,
           )
       )
     // --8<-- [end:custom-quote]
+  }
+
+  @Test
+  fun customRecordDelimiter() {
+    @Serializable data class Row(val id: Int, val name: String)
+
+    val rows = listOf(Row(1, "Ada"), Row(2, "Grace"))
+
+    // --8<-- [start:custom-record-delimiter]
+    val mysqlOutfile =
+      DsvFormat(
+        scheme = DsvScheme(delimiter = ',', recordDelimiter = RecordDelimiter.Exact("\n%%\n"))
+      )
+
+    val dumped = mysqlOutfile.encodeToString(rows)
+    val decoded = mysqlOutfile.decodeFromString<Row>(dumped)
+    // --8<-- [end:custom-record-delimiter]
+    assertEquals(rows, decoded)
+    assertEquals("id,name\n%%\n1,Ada\n%%\n2,Grace\n%%\n", dumped)
   }
 
   // --8<-- [start:enum-class]

--- a/kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/DocsTest.kt
+++ b/kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/DocsTest.kt
@@ -223,7 +223,9 @@ class DocsTest {
 
     // --8<-- [start:custom-record-delimiter]
     val mysqlOutfile =
-      DsvFormat(scheme = DsvScheme(delimiter = ',', recordDelimiter = RecordDelimiter("\n%%\n")))
+      DsvFormat(
+        scheme = DsvScheme(delimiter = ',', recordDelimiter = RecordDelimiter.Exact("\n%%\n"))
+      )
 
     val dumped = mysqlOutfile.encodeToString(rows)
     val decoded = mysqlOutfile.decodeFromString<Row>(dumped)

--- a/kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/EncoderDecoderTest.kt
+++ b/kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/EncoderDecoderTest.kt
@@ -84,7 +84,7 @@ class EncoderDecoderTest {
 
   object NestedTokenSerializer : KSerializer<NestedToken> by NestedToken.serializer()
 
-  private val format = DsvFormat(DsvScheme(delimiter = ',', writeCrlf = false))
+  private val format = DsvFormat(DsvScheme(delimiter = ',', recordDelimiter = RecordDelimiter.Lf))
 
   @Test
   fun encodeBasicList() {
@@ -172,7 +172,10 @@ class EncoderDecoderTest {
   @Test
   fun encodeEnumsByOrdinal() {
     val formatByOrdinal =
-      DsvFormat(DsvScheme(delimiter = ',', writeCrlf = false), writeEnumsByName = false)
+      DsvFormat(
+        DsvScheme(delimiter = ',', recordDelimiter = RecordDelimiter.Lf),
+        writeEnumsByName = false,
+      )
     val samples = listOf(Sample(1, "Item", 9.99, null, true, Status.PENDING, null))
 
     val result = formatByOrdinal.encodeToString(samples)
@@ -195,7 +198,7 @@ class EncoderDecoderTest {
   fun encodeWithSnakeCaseNaming() {
     val formatSnakeCase =
       DsvFormat(
-        scheme = DsvScheme(delimiter = ',', writeCrlf = false),
+        scheme = DsvScheme(delimiter = ',', recordDelimiter = RecordDelimiter.Lf),
         namingStrategy = DsvNamingStrategy.SnakeCase,
       )
 
@@ -234,7 +237,7 @@ class EncoderDecoderTest {
   fun treatMissingColumnsAsNull() {
     val formatWithOption =
       DsvFormat(
-        scheme = DsvScheme(delimiter = ',', writeCrlf = false),
+        scheme = DsvScheme(delimiter = ',', recordDelimiter = RecordDelimiter.Lf),
         treatMissingColumnsAsNull = true,
       )
 
@@ -291,7 +294,7 @@ class EncoderDecoderTest {
         scheme =
           DsvScheme(
             delimiter = ',',
-            writeCrlf = false,
+            recordDelimiter = RecordDelimiter.Lf,
             shortRowPolicy = ShortRowPolicy.Pad,
             longRowPolicy = LongRowPolicy.Truncate,
           )
@@ -322,7 +325,7 @@ class EncoderDecoderTest {
         scheme =
           DsvScheme(
             delimiter = ',',
-            writeCrlf = false,
+            recordDelimiter = RecordDelimiter.Lf,
             shortRowPolicy = ShortRowPolicy.Skip,
             longRowPolicy = LongRowPolicy.Skip,
           )
@@ -351,7 +354,7 @@ class EncoderDecoderTest {
         scheme =
           DsvScheme(
             delimiter = ',',
-            writeCrlf = false,
+            recordDelimiter = RecordDelimiter.Lf,
             shortRowPolicy = ShortRowPolicy.Pad,
             longRowPolicy = LongRowPolicy.Skip,
           )
@@ -487,7 +490,7 @@ class EncoderDecoderTest {
   fun contextualPrimitiveLike() {
     val format =
       DsvFormat(
-        scheme = DsvScheme(delimiter = ',', writeCrlf = false),
+        scheme = DsvScheme(delimiter = ',', recordDelimiter = RecordDelimiter.Lf),
         serializersModule = SerializersModule { contextual(TokenAsStringSerializer) },
       )
 
@@ -514,7 +517,7 @@ class EncoderDecoderTest {
   fun contextualNestedClassFails() {
     val format =
       DsvFormat(
-        scheme = DsvScheme(delimiter = ',', writeCrlf = false),
+        scheme = DsvScheme(delimiter = ',', recordDelimiter = RecordDelimiter.Lf),
         serializersModule = SerializersModule { contextual(NestedTokenSerializer) },
       )
 

--- a/kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/RecordDelimiterTest.kt
+++ b/kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/RecordDelimiterTest.kt
@@ -1,0 +1,136 @@
+package dev.sargunv.kotlindsv
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlinx.io.Buffer
+import kotlinx.io.readString
+import kotlinx.io.writeString
+
+class RecordDelimiterTest {
+
+  private fun parse(input: String, scheme: DsvScheme): List<List<String>> {
+    val buffer = Buffer()
+    buffer.writeString(input)
+    return DsvParser(buffer, scheme).parseRecords().toList()
+  }
+
+  private fun write(records: List<List<String>>, scheme: DsvScheme): String {
+    val buffer = Buffer()
+    DsvWriter(buffer, scheme).write(records)
+    return buffer.readString()
+  }
+
+  private fun scheme(recordDelimiter: RecordDelimiter) =
+    DsvScheme(delimiter = ',', recordDelimiter = recordDelimiter)
+
+  @Test
+  fun conventionalLfWritesUnixNewlines() {
+    val output = write(listOf(listOf("a", "b"), listOf("1", "2")), scheme(RecordDelimiter.Lf))
+    assertEquals("a,b\n1,2\n", output)
+  }
+
+  @Test
+  fun conventionalCrlfWritesWindowsNewlines() {
+    val output = write(listOf(listOf("a", "b"), listOf("1", "2")), scheme(RecordDelimiter.CrLf))
+    assertEquals("a,b\r\n1,2\r\n", output)
+  }
+
+  @Test
+  fun conventionalReadAcceptsLfCrLfAndCrcrlf() {
+    val scheme = scheme(RecordDelimiter.CrLf)
+    assertEquals(listOf(listOf("a"), listOf("b")), parse("a\nb", scheme))
+    assertEquals(listOf(listOf("a"), listOf("b")), parse("a\r\nb", scheme))
+    assertEquals(listOf(listOf("a"), listOf("b")), parse("a\r\r\nb", scheme))
+  }
+
+  @Test
+  fun exactCrReadsAndWritesOldMacFiles() {
+    val scheme = scheme(RecordDelimiter.Exact("\r"))
+    assertEquals(listOf(listOf("a", "b"), listOf("1", "2")), parse("a,b\r1,2\r", scheme))
+    assertEquals("a,b\r1,2\r", write(listOf(listOf("a", "b"), listOf("1", "2")), scheme))
+  }
+
+  @Test
+  fun exactLfKeepsCarriageReturnInField() {
+    val scheme = scheme(RecordDelimiter.Exact("\n"))
+    assertEquals(listOf(listOf("a\r"), listOf("b")), parse("a\r\nb", scheme))
+  }
+
+  @Test
+  fun exactMultiCharacterMysqlLinesTerminatedBy() {
+    val scheme = scheme(RecordDelimiter.Exact("\n%%\n"))
+    val input = "a,b\n%%\n1,2\n%%\n"
+    assertEquals(listOf(listOf("a", "b"), listOf("1", "2")), parse(input, scheme))
+    assertEquals(input, write(listOf(listOf("a", "b"), listOf("1", "2")), scheme))
+  }
+
+  @Test
+  fun exactRecordSeparatorChar() {
+    val scheme = scheme(RecordDelimiter.Exact("\u001e"))
+    val input = "a,b\u001e1,2\u001e"
+    assertEquals(listOf(listOf("a", "b"), listOf("1", "2")), parse(input, scheme))
+    assertEquals(input, write(listOf(listOf("a", "b"), listOf("1", "2")), scheme))
+  }
+
+  @Test
+  fun prefixOfMultiCharacterDelimiterStaysInField() {
+    val scheme = scheme(RecordDelimiter.Exact("%%"))
+    assertEquals(listOf(listOf("a%", "b"), listOf("1", "2")), parse("a%,b%%1,2", scheme))
+  }
+
+  @Test
+  fun quotedFieldMayContainExactDelimiter() {
+    val scheme = scheme(RecordDelimiter.Exact("%%"))
+    assertEquals(listOf(listOf("a%%b", "c")), parse("\"a%%b\",c%%", scheme))
+    assertEquals("\"a%%b\",c%%", write(listOf(listOf("a%%b", "c")), scheme))
+  }
+
+  @Test
+  fun exactDelimiterDoesNotQuoteLoneNewlines() {
+    val scheme = scheme(RecordDelimiter.Exact("%%"))
+    assertEquals("a\nb,c%%", write(listOf(listOf("a\nb", "c")), scheme))
+    assertEquals(listOf(listOf("a\nb", "c")), parse("a\nb,c%%", scheme))
+  }
+
+  @Test
+  fun conventionalStillQuotesEmbeddedNewlines() {
+    val scheme = scheme(RecordDelimiter.Lf)
+    assertEquals("\"a\nb\",c\n", write(listOf(listOf("a\nb", "c")), scheme))
+  }
+
+  @Test
+  fun skipEmptyRecordsWithExactDelimiter() {
+    val scheme =
+      DsvScheme(
+        delimiter = ',',
+        recordDelimiter = RecordDelimiter.Exact("%%"),
+        skipEmptyLines = true,
+      )
+    assertEquals(listOf(listOf("a", "b"), listOf("1", "2")), parse("a,b%%%%1,2%%", scheme))
+  }
+
+  @Test
+  fun trailingExactDelimiterIsOptional() {
+    val scheme = scheme(RecordDelimiter.Exact("%%"))
+    assertEquals(listOf(listOf("a", "b")), parse("a,b", scheme))
+  }
+
+  @Test
+  fun incompleteExactDelimiterIsFieldContent() {
+    val scheme = scheme(RecordDelimiter.Exact("\n%%\n"))
+    assertEquals(listOf(listOf("a", "b\n%%")), parse("a,b\n%%", scheme))
+  }
+
+  @Test
+  fun unexpectedCharacterAfterExactField() {
+    val scheme = scheme(RecordDelimiter.Exact("%%"))
+    assertFailsWith<DsvParseException> { parse("\"quoted\"x%%", scheme) }
+  }
+
+  @Test
+  fun newlineFieldDelimiterWithPercentRecords() {
+    val scheme = DsvScheme(delimiter = '\n', recordDelimiter = RecordDelimiter.Exact("%%"))
+    assertEquals(listOf(listOf("a", "b"), listOf("1", "2")), parse("a\nb%%1\n2", scheme))
+  }
+}

--- a/kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/RecordDelimiterTest.kt
+++ b/kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/RecordDelimiterTest.kt
@@ -87,6 +87,49 @@ class RecordDelimiterTest {
   }
 
   @Test
+  fun exactDelimiterSuffixOverlapRoundTrips() {
+    val scheme = scheme(RecordDelimiter.Exact("%%"))
+    val records = listOf(listOf("%"))
+    val output = write(records, scheme)
+    assertEquals("\"%\"%%", output)
+    assertEquals(records, parse(output, scheme))
+  }
+
+  @Test
+  fun exactDelimiterLastFieldSuffixOverlapRoundTrips() {
+    val scheme = scheme(RecordDelimiter.Exact("%%"))
+    val records = listOf(listOf("a", "x%"))
+    val output = write(records, scheme)
+    assertEquals("a,\"x%\"%%", output)
+    assertEquals(records, parse(output, scheme))
+  }
+
+  @Test
+  fun exactSelfOverlappingDelimiterRoundTrips() {
+    val scheme = scheme(RecordDelimiter.Exact("aba"))
+    val records = listOf(listOf("ab"))
+    val output = write(records, scheme)
+    assertEquals("\"ab\"aba", output)
+    assertEquals(records, parse(output, scheme))
+  }
+
+  @Test
+  fun exactDelimiterPrefixInNonLastFieldStaysUnquoted() {
+    val scheme = scheme(RecordDelimiter.Exact("%%"))
+    assertEquals("%,b%%", write(listOf(listOf("%", "b")), scheme))
+    assertEquals(listOf(listOf("%", "b")), parse("%,b%%", scheme))
+  }
+
+  @Test
+  fun exactDelimiterMayContainBomAfterFirstChar() {
+    val scheme = scheme(RecordDelimiter.Exact("x\uFEFF"))
+    val records = listOf(listOf("a"), listOf("b"))
+    val output = write(records, scheme)
+    assertEquals("ax\uFEFFbx\uFEFF", output)
+    assertEquals(records, parse(output, scheme))
+  }
+
+  @Test
   fun quotedFieldMayContainExactDelimiter() {
     val scheme = scheme(RecordDelimiter.Exact("%%"))
     assertEquals(listOf(listOf("a%%b", "c")), parse("\"a%%b\",c%%", scheme))

--- a/kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/RecordDelimiterTest.kt
+++ b/kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/RecordDelimiterTest.kt
@@ -37,7 +37,7 @@ class RecordDelimiterTest {
   }
 
   @Test
-  fun conventionalReadAcceptsLfCrLfAndCrcrlf() {
+  fun conventionalReadAcceptsLfCrlfAndCrcrlf() {
     val scheme = scheme(RecordDelimiter.CrLf)
     assertEquals(listOf(listOf("a"), listOf("b")), parse("a\nb", scheme))
     assertEquals(listOf(listOf("a"), listOf("b")), parse("a\r\nb", scheme))
@@ -45,21 +45,51 @@ class RecordDelimiterTest {
   }
 
   @Test
+  fun conventionalReadLeavesAThirdCrInField() {
+    val scheme = scheme(RecordDelimiter.CrLf)
+    assertEquals(listOf(listOf("a\r"), listOf("b")), parse("a\r\r\r\nb", scheme))
+  }
+
+  @Test
+  fun customReadSetCanIncludeCarriageReturn() {
+    val scheme = scheme(RecordDelimiter(write = "\n", read = listOf("\n", "\r\n", "\r")))
+    assertEquals(listOf(listOf("a"), listOf("b")), parse("a\rb", scheme))
+  }
+
+  @Test
+  fun lfIsWritePlusConventionalRead() {
+    assertEquals(
+      RecordDelimiter(write = "\n", read = listOf("\r\r\n", "\r\n", "\n")),
+      RecordDelimiter.Lf,
+    )
+    assertEquals(
+      RecordDelimiter(write = "\r\n", read = listOf("\r\r\n", "\r\n", "\n")),
+      RecordDelimiter.CrLf,
+    )
+  }
+
+  @Test
+  fun longestReadTokenWins() {
+    val scheme = scheme(RecordDelimiter(write = "%%", read = listOf("%", "%%")))
+    assertEquals(listOf(listOf("a"), listOf("b")), parse("a%%b", scheme))
+  }
+
+  @Test
   fun exactCrReadsAndWritesOldMacFiles() {
-    val scheme = scheme(RecordDelimiter.Exact("\r"))
+    val scheme = scheme(RecordDelimiter("\r"))
     assertEquals(listOf(listOf("a", "b"), listOf("1", "2")), parse("a,b\r1,2\r", scheme))
     assertEquals("a,b\r1,2\r", write(listOf(listOf("a", "b"), listOf("1", "2")), scheme))
   }
 
   @Test
   fun exactLfKeepsCarriageReturnInField() {
-    val scheme = scheme(RecordDelimiter.Exact("\n"))
+    val scheme = scheme(RecordDelimiter("\n"))
     assertEquals(listOf(listOf("a\r"), listOf("b")), parse("a\r\nb", scheme))
   }
 
   @Test
   fun exactMultiCharacterMysqlLinesTerminatedBy() {
-    val scheme = scheme(RecordDelimiter.Exact("\n%%\n"))
+    val scheme = scheme(RecordDelimiter("\n%%\n"))
     val input = "a,b\n%%\n1,2\n%%\n"
     assertEquals(listOf(listOf("a", "b"), listOf("1", "2")), parse(input, scheme))
     assertEquals(input, write(listOf(listOf("a", "b"), listOf("1", "2")), scheme))
@@ -67,7 +97,7 @@ class RecordDelimiterTest {
 
   @Test
   fun exactRecordSeparatorChar() {
-    val scheme = scheme(RecordDelimiter.Exact("\u001e"))
+    val scheme = scheme(RecordDelimiter("\u001e"))
     val input = "a,b\u001e1,2\u001e"
     assertEquals(listOf(listOf("a", "b"), listOf("1", "2")), parse(input, scheme))
     assertEquals(input, write(listOf(listOf("a", "b"), listOf("1", "2")), scheme))
@@ -75,20 +105,20 @@ class RecordDelimiterTest {
 
   @Test
   fun prefixOfMultiCharacterDelimiterStaysInField() {
-    val scheme = scheme(RecordDelimiter.Exact("%%"))
+    val scheme = scheme(RecordDelimiter("%%"))
     assertEquals(listOf(listOf("a%", "b"), listOf("1", "2")), parse("a%,b%%1,2", scheme))
   }
 
   @Test
   fun quotedFieldMayContainExactDelimiter() {
-    val scheme = scheme(RecordDelimiter.Exact("%%"))
+    val scheme = scheme(RecordDelimiter("%%"))
     assertEquals(listOf(listOf("a%%b", "c")), parse("\"a%%b\",c%%", scheme))
     assertEquals("\"a%%b\",c%%", write(listOf(listOf("a%%b", "c")), scheme))
   }
 
   @Test
   fun exactDelimiterDoesNotQuoteLoneNewlines() {
-    val scheme = scheme(RecordDelimiter.Exact("%%"))
+    val scheme = scheme(RecordDelimiter("%%"))
     assertEquals("a\nb,c%%", write(listOf(listOf("a\nb", "c")), scheme))
     assertEquals(listOf(listOf("a\nb", "c")), parse("a\nb,c%%", scheme))
   }
@@ -104,7 +134,7 @@ class RecordDelimiterTest {
     val scheme =
       DsvScheme(
         delimiter = ',',
-        recordDelimiter = RecordDelimiter.Exact("%%"),
+        recordDelimiter = RecordDelimiter("%%"),
         skipEmptyLines = true,
       )
     assertEquals(listOf(listOf("a", "b"), listOf("1", "2")), parse("a,b%%%%1,2%%", scheme))
@@ -112,25 +142,25 @@ class RecordDelimiterTest {
 
   @Test
   fun trailingExactDelimiterIsOptional() {
-    val scheme = scheme(RecordDelimiter.Exact("%%"))
+    val scheme = scheme(RecordDelimiter("%%"))
     assertEquals(listOf(listOf("a", "b")), parse("a,b", scheme))
   }
 
   @Test
   fun incompleteExactDelimiterIsFieldContent() {
-    val scheme = scheme(RecordDelimiter.Exact("\n%%\n"))
+    val scheme = scheme(RecordDelimiter("\n%%\n"))
     assertEquals(listOf(listOf("a", "b\n%%")), parse("a,b\n%%", scheme))
   }
 
   @Test
   fun unexpectedCharacterAfterExactField() {
-    val scheme = scheme(RecordDelimiter.Exact("%%"))
+    val scheme = scheme(RecordDelimiter("%%"))
     assertFailsWith<DsvParseException> { parse("\"quoted\"x%%", scheme) }
   }
 
   @Test
   fun newlineFieldDelimiterWithPercentRecords() {
-    val scheme = DsvScheme(delimiter = '\n', recordDelimiter = RecordDelimiter.Exact("%%"))
+    val scheme = DsvScheme(delimiter = '\n', recordDelimiter = RecordDelimiter("%%"))
     assertEquals(listOf(listOf("a", "b"), listOf("1", "2")), parse("a\nb%%1\n2", scheme))
   }
 }

--- a/kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/RecordDelimiterTest.kt
+++ b/kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/RecordDelimiterTest.kt
@@ -25,19 +25,19 @@ class RecordDelimiterTest {
     DsvScheme(delimiter = ',', recordDelimiter = recordDelimiter)
 
   @Test
-  fun conventionalLfWritesUnixNewlines() {
+  fun lfWritesUnixNewlines() {
     val output = write(listOf(listOf("a", "b"), listOf("1", "2")), scheme(RecordDelimiter.Lf))
     assertEquals("a,b\n1,2\n", output)
   }
 
   @Test
-  fun conventionalCrlfWritesWindowsNewlines() {
+  fun crlfWritesWindowsNewlines() {
     val output = write(listOf(listOf("a", "b"), listOf("1", "2")), scheme(RecordDelimiter.CrLf))
     assertEquals("a,b\r\n1,2\r\n", output)
   }
 
   @Test
-  fun conventionalReadAcceptsLfCrlfAndCrcrlf() {
+  fun newlineModesReadLfCrlfAndCrcrlf() {
     val scheme = scheme(RecordDelimiter.CrLf)
     assertEquals(listOf(listOf("a"), listOf("b")), parse("a\nb", scheme))
     assertEquals(listOf(listOf("a"), listOf("b")), parse("a\r\nb", scheme))
@@ -45,46 +45,28 @@ class RecordDelimiterTest {
   }
 
   @Test
-  fun conventionalReadAcceptsAnyNumberOfCrsBeforeLf() {
+  fun newlineModesReadAnyNumberOfCrsBeforeLf() {
     val scheme = scheme(RecordDelimiter.CrLf)
     assertEquals(listOf(listOf("a"), listOf("b")), parse("a\r\r\r\nb", scheme))
     assertEquals(listOf(listOf("a"), listOf("b")), parse("a" + "\r".repeat(8) + "\nb", scheme))
   }
 
   @Test
-  fun customReadSetCanIncludeCarriageReturn() {
-    val scheme = scheme(RecordDelimiter(write = "\n", read = listOf("\n", "\r\n", "\r")))
-    assertEquals(listOf(listOf("a"), listOf("b")), parse("a\rb", scheme))
-  }
-
-  @Test
-  fun exactLfAndCrlfTokensDoNotEatExtraCrs() {
-    val scheme = scheme(RecordDelimiter(write = "\n", read = listOf("\r\n", "\n")))
-    assertEquals(listOf(listOf("a\r"), listOf("b")), parse("a\r\r\nb", scheme))
-  }
-
-  @Test
-  fun longestReadTokenWins() {
-    val scheme = scheme(RecordDelimiter(write = "%%", read = listOf("%", "%%")))
-    assertEquals(listOf(listOf("a"), listOf("b")), parse("a%%b", scheme))
-  }
-
-  @Test
   fun exactCrReadsAndWritesOldMacFiles() {
-    val scheme = scheme(RecordDelimiter("\r"))
+    val scheme = scheme(RecordDelimiter.Exact("\r"))
     assertEquals(listOf(listOf("a", "b"), listOf("1", "2")), parse("a,b\r1,2\r", scheme))
     assertEquals("a,b\r1,2\r", write(listOf(listOf("a", "b"), listOf("1", "2")), scheme))
   }
 
   @Test
   fun exactLfKeepsCarriageReturnInField() {
-    val scheme = scheme(RecordDelimiter("\n"))
+    val scheme = scheme(RecordDelimiter.Exact("\n"))
     assertEquals(listOf(listOf("a\r"), listOf("b")), parse("a\r\nb", scheme))
   }
 
   @Test
   fun exactMultiCharacterMysqlLinesTerminatedBy() {
-    val scheme = scheme(RecordDelimiter("\n%%\n"))
+    val scheme = scheme(RecordDelimiter.Exact("\n%%\n"))
     val input = "a,b\n%%\n1,2\n%%\n"
     assertEquals(listOf(listOf("a", "b"), listOf("1", "2")), parse(input, scheme))
     assertEquals(input, write(listOf(listOf("a", "b"), listOf("1", "2")), scheme))
@@ -92,7 +74,7 @@ class RecordDelimiterTest {
 
   @Test
   fun exactRecordSeparatorChar() {
-    val scheme = scheme(RecordDelimiter("\u001e"))
+    val scheme = scheme(RecordDelimiter.Exact("\u001e"))
     val input = "a,b\u001e1,2\u001e"
     assertEquals(listOf(listOf("a", "b"), listOf("1", "2")), parse(input, scheme))
     assertEquals(input, write(listOf(listOf("a", "b"), listOf("1", "2")), scheme))
@@ -100,26 +82,26 @@ class RecordDelimiterTest {
 
   @Test
   fun prefixOfMultiCharacterDelimiterStaysInField() {
-    val scheme = scheme(RecordDelimiter("%%"))
+    val scheme = scheme(RecordDelimiter.Exact("%%"))
     assertEquals(listOf(listOf("a%", "b"), listOf("1", "2")), parse("a%,b%%1,2", scheme))
   }
 
   @Test
   fun quotedFieldMayContainExactDelimiter() {
-    val scheme = scheme(RecordDelimiter("%%"))
+    val scheme = scheme(RecordDelimiter.Exact("%%"))
     assertEquals(listOf(listOf("a%%b", "c")), parse("\"a%%b\",c%%", scheme))
     assertEquals("\"a%%b\",c%%", write(listOf(listOf("a%%b", "c")), scheme))
   }
 
   @Test
   fun exactDelimiterDoesNotQuoteLoneNewlines() {
-    val scheme = scheme(RecordDelimiter("%%"))
+    val scheme = scheme(RecordDelimiter.Exact("%%"))
     assertEquals("a\nb,c%%", write(listOf(listOf("a\nb", "c")), scheme))
     assertEquals(listOf(listOf("a\nb", "c")), parse("a\nb,c%%", scheme))
   }
 
   @Test
-  fun conventionalStillQuotesEmbeddedNewlines() {
+  fun newlineModesQuoteEmbeddedNewlines() {
     val scheme = scheme(RecordDelimiter.Lf)
     assertEquals("\"a\nb\",c\n", write(listOf(listOf("a\nb", "c")), scheme))
   }
@@ -129,7 +111,7 @@ class RecordDelimiterTest {
     val scheme =
       DsvScheme(
         delimiter = ',',
-        recordDelimiter = RecordDelimiter("%%"),
+        recordDelimiter = RecordDelimiter.Exact("%%"),
         skipEmptyLines = true,
       )
     assertEquals(listOf(listOf("a", "b"), listOf("1", "2")), parse("a,b%%%%1,2%%", scheme))
@@ -137,25 +119,25 @@ class RecordDelimiterTest {
 
   @Test
   fun trailingExactDelimiterIsOptional() {
-    val scheme = scheme(RecordDelimiter("%%"))
+    val scheme = scheme(RecordDelimiter.Exact("%%"))
     assertEquals(listOf(listOf("a", "b")), parse("a,b", scheme))
   }
 
   @Test
   fun incompleteExactDelimiterIsFieldContent() {
-    val scheme = scheme(RecordDelimiter("\n%%\n"))
+    val scheme = scheme(RecordDelimiter.Exact("\n%%\n"))
     assertEquals(listOf(listOf("a", "b\n%%")), parse("a,b\n%%", scheme))
   }
 
   @Test
   fun unexpectedCharacterAfterExactField() {
-    val scheme = scheme(RecordDelimiter("%%"))
+    val scheme = scheme(RecordDelimiter.Exact("%%"))
     assertFailsWith<DsvParseException> { parse("\"quoted\"x%%", scheme) }
   }
 
   @Test
   fun newlineFieldDelimiterWithPercentRecords() {
-    val scheme = DsvScheme(delimiter = '\n', recordDelimiter = RecordDelimiter("%%"))
+    val scheme = DsvScheme(delimiter = '\n', recordDelimiter = RecordDelimiter.Exact("%%"))
     assertEquals(listOf(listOf("a", "b"), listOf("1", "2")), parse("a\nb%%1\n2", scheme))
   }
 }

--- a/kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/RecordDelimiterTest.kt
+++ b/kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/RecordDelimiterTest.kt
@@ -45,9 +45,10 @@ class RecordDelimiterTest {
   }
 
   @Test
-  fun conventionalReadLeavesAThirdCrInField() {
+  fun conventionalReadAcceptsAnyNumberOfCrsBeforeLf() {
     val scheme = scheme(RecordDelimiter.CrLf)
-    assertEquals(listOf(listOf("a\r"), listOf("b")), parse("a\r\r\r\nb", scheme))
+    assertEquals(listOf(listOf("a"), listOf("b")), parse("a\r\r\r\nb", scheme))
+    assertEquals(listOf(listOf("a"), listOf("b")), parse("a" + "\r".repeat(8) + "\nb", scheme))
   }
 
   @Test
@@ -57,15 +58,9 @@ class RecordDelimiterTest {
   }
 
   @Test
-  fun lfIsWritePlusConventionalRead() {
-    assertEquals(
-      RecordDelimiter(write = "\n", read = listOf("\r\r\n", "\r\n", "\n")),
-      RecordDelimiter.Lf,
-    )
-    assertEquals(
-      RecordDelimiter(write = "\r\n", read = listOf("\r\r\n", "\r\n", "\n")),
-      RecordDelimiter.CrLf,
-    )
+  fun exactLfAndCrlfTokensDoNotEatExtraCrs() {
+    val scheme = scheme(RecordDelimiter(write = "\n", read = listOf("\r\n", "\n")))
+    assertEquals(listOf(listOf("a\r"), listOf("b")), parse("a\r\r\nb", scheme))
   }
 
   @Test

--- a/kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/SchemeTest.kt
+++ b/kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/SchemeTest.kt
@@ -29,4 +29,28 @@ class SchemeTest {
   fun delimiterEqualsCarriageReturn() {
     assertFailsWith<IllegalArgumentException> { DsvScheme(delimiter = '\r') }
   }
+
+  @Test
+  fun emptyExactRecordDelimiter() {
+    assertFailsWith<IllegalArgumentException> { RecordDelimiter.Exact("") }
+  }
+
+  @Test
+  fun quoteInExactRecordDelimiter() {
+    assertFailsWith<IllegalArgumentException> {
+      DsvScheme(delimiter = ',', recordDelimiter = RecordDelimiter.Exact("\n\"\n"))
+    }
+  }
+
+  @Test
+  fun delimiterInExactRecordDelimiter() {
+    assertFailsWith<IllegalArgumentException> {
+      DsvScheme(delimiter = ',', recordDelimiter = RecordDelimiter.Exact(",\n"))
+    }
+  }
+
+  @Test
+  fun newlineFieldDelimiterWithCustomRecordDelimiter() {
+    DsvScheme(delimiter = '\n', recordDelimiter = RecordDelimiter.Exact("%%"))
+  }
 }

--- a/kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/SchemeTest.kt
+++ b/kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/SchemeTest.kt
@@ -31,38 +31,26 @@ class SchemeTest {
   }
 
   @Test
-  fun emptyWriteRecordDelimiter() {
-    assertFailsWith<IllegalArgumentException> { RecordDelimiter("") }
-  }
-
-  @Test
-  fun emptyReadRecordDelimiter() {
-    assertFailsWith<IllegalArgumentException> { RecordDelimiter(write = "\n", read = emptyList()) }
-  }
-
-  @Test
-  fun emptyReadToken() {
-    assertFailsWith<IllegalArgumentException> {
-      RecordDelimiter(write = "\n", read = listOf("\n", ""))
-    }
+  fun emptyExactRecordDelimiter() {
+    assertFailsWith<IllegalArgumentException> { RecordDelimiter.Exact("") }
   }
 
   @Test
   fun quoteInExactRecordDelimiter() {
     assertFailsWith<IllegalArgumentException> {
-      DsvScheme(delimiter = ',', recordDelimiter = RecordDelimiter("\n\"\n"))
+      DsvScheme(delimiter = ',', recordDelimiter = RecordDelimiter.Exact("\n\"\n"))
     }
   }
 
   @Test
   fun delimiterInExactRecordDelimiter() {
     assertFailsWith<IllegalArgumentException> {
-      DsvScheme(delimiter = ',', recordDelimiter = RecordDelimiter(",\n"))
+      DsvScheme(delimiter = ',', recordDelimiter = RecordDelimiter.Exact(",\n"))
     }
   }
 
   @Test
   fun newlineFieldDelimiterWithCustomRecordDelimiter() {
-    DsvScheme(delimiter = '\n', recordDelimiter = RecordDelimiter("%%"))
+    DsvScheme(delimiter = '\n', recordDelimiter = RecordDelimiter.Exact("%%"))
   }
 }

--- a/kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/SchemeTest.kt
+++ b/kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/SchemeTest.kt
@@ -36,6 +36,12 @@ class SchemeTest {
   }
 
   @Test
+  fun exactRecordDelimiterMustNotStartWithBom() {
+    assertFailsWith<IllegalArgumentException> { RecordDelimiter.Exact("\uFEFF") }
+    assertFailsWith<IllegalArgumentException> { RecordDelimiter.Exact("\uFEFFx") }
+  }
+
+  @Test
   fun quoteInExactRecordDelimiter() {
     assertFailsWith<IllegalArgumentException> {
       DsvScheme(delimiter = ',', recordDelimiter = RecordDelimiter.Exact("\n\"\n"))

--- a/kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/SchemeTest.kt
+++ b/kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/SchemeTest.kt
@@ -31,26 +31,38 @@ class SchemeTest {
   }
 
   @Test
-  fun emptyExactRecordDelimiter() {
-    assertFailsWith<IllegalArgumentException> { RecordDelimiter.Exact("") }
+  fun emptyWriteRecordDelimiter() {
+    assertFailsWith<IllegalArgumentException> { RecordDelimiter("") }
+  }
+
+  @Test
+  fun emptyReadRecordDelimiter() {
+    assertFailsWith<IllegalArgumentException> { RecordDelimiter(write = "\n", read = emptyList()) }
+  }
+
+  @Test
+  fun emptyReadToken() {
+    assertFailsWith<IllegalArgumentException> {
+      RecordDelimiter(write = "\n", read = listOf("\n", ""))
+    }
   }
 
   @Test
   fun quoteInExactRecordDelimiter() {
     assertFailsWith<IllegalArgumentException> {
-      DsvScheme(delimiter = ',', recordDelimiter = RecordDelimiter.Exact("\n\"\n"))
+      DsvScheme(delimiter = ',', recordDelimiter = RecordDelimiter("\n\"\n"))
     }
   }
 
   @Test
   fun delimiterInExactRecordDelimiter() {
     assertFailsWith<IllegalArgumentException> {
-      DsvScheme(delimiter = ',', recordDelimiter = RecordDelimiter.Exact(",\n"))
+      DsvScheme(delimiter = ',', recordDelimiter = RecordDelimiter(",\n"))
     }
   }
 
   @Test
   fun newlineFieldDelimiterWithCustomRecordDelimiter() {
-    DsvScheme(delimiter = '\n', recordDelimiter = RecordDelimiter.Exact("%%"))
+    DsvScheme(delimiter = '\n', recordDelimiter = RecordDelimiter("%%"))
   }
 }

--- a/kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/WriterTest.kt
+++ b/kotlin-dsv/src/commonTest/kotlin/dev/sargunv/kotlindsv/WriterTest.kt
@@ -13,7 +13,7 @@ class WriterTest {
     block: DsvWriter.() -> Unit,
   ) {
     val buffer = Buffer()
-    val writer = DsvWriter(buffer, DsvScheme(delimiter, writeCrlf = false))
+    val writer = DsvWriter(buffer, DsvScheme(delimiter, recordDelimiter = RecordDelimiter.Lf))
     writer.block()
     assertEquals(expected.trim(), buffer.readString().trim())
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Replace `writeCrlf` with a sealed `RecordDelimiter`. `Lf` and `CrLf` write that newline and read `\r*\n`. `Exact` is the same string on both sides. There is no general write/read list.

## Validation

JVM and Linux native suites passed locally after restoring the sealed API.

## AI assistance

Cursor Grok 4.6 cloud agent.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f4a02acc-8bad-40d8-8fc4-1c6c4f2a1ba5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f4a02acc-8bad-40d8-8fc4-1c6c4f2a1ba5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

